### PR TITLE
Julie about us

### DIFF
--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -3,17 +3,32 @@ title: About
 type: docs
 ---
 
-- We are a National Center funded through the NIH
-- What we do:  Enhance reproducibility of neuroimaging by developing and disseminating and spurring adoption of key concepts, practices and tools
-- What does ReproNim offer:  Educate and enable individual researchers, imaging centers and students on why reproducible neuroimaging is important and how to do it through principles, tools and training.
-- Who we are: how are we organized/governed → TRD’s
-    - Staff + linked profiles
-    - [External Advisory Board](eab/index.html)
-    - Collaborator:  Link to collaborator page
-- Grant Support (could also go in footer)
-- Where have we been/where are we going?  History of ReproNim and the ReproNim Roadmap
-- Join the ReproNim community
-- Publications about ReproNim
-- Contact us
-- Sign up for our mailing list
+## ReproNim is a National Center funded through the NIH
 
+ReproNim is a National multi-site technology and research development Center for reproducible neuroimaging computation, funded by a P41 award from the National Institute of Biomedical Imaging and Bioengineering. 
+Collectively, our project and core teams are based across six sites (UMassChan Medical School, MIT, Dartmouth College, McGill, UCSD, and UCI) in North America.
+
+## What we do
+
+Our mission is to enhance reproducibility of neuroimaging research by developing, disseminating and spurring adoption of key concepts, practices and tools.
+
+## What we offer
+
+ReproNim offers a variety of resources to educate and enable individual researchers, imaging centers and students on both conceptual and practical fundamentals of  reproducible neuroimaging, why it is important and how to do it through principles, tools and training.
+
+## ReproNim/INCF Fellows
+ 
+The ReproNim/INCF Fellows (33 graduates, and 12 current fellows) are an important extension of ReproNim, with international representation and educational reach to highly varied audiences encompassing all career stages and diverse resources. 
+The ReproNim/INCF Fellowship is a full year, project-based Train-the-Trainer program, with access to networking and mentorship in support of Fellows' training program development endeavors, which are tailored to their respective target audiences, training objectives, and local environs.
+The program is open by competitive review, to applicants at all career stages.
+
+## Join the ReproNim Community
+
+ - Sign up for our mailing list [TODO link]
+ - Follow our [webinar series](https://www.youtube.com/channel/UCGX2sXmEgDuUGWHDSiT1NdQ/videos)
+ - Read [The ReproNim Blog](https://repronim.wordpress.com/)
+ - [Become a Fellow](/fellowship)
+
+## Contact us
+
+Email us at <info@repronim.org>

--- a/content/about/collaborators.md
+++ b/content/about/collaborators.md
@@ -1,0 +1,10 @@
+---
+title: Collaborators
+type: docs
+---
+
+Our efforts are substantially informed and enhanced through the breadth and depth of scientific expertise of our collaborative liaisons, including both Collaborating Projects and Service Projects.
+
+## Collaborating Projects
+
+## Service Projects

--- a/content/about/team.md
+++ b/content/about/team.md
@@ -1,0 +1,12 @@
+---
+title: ReproNim Team
+type: docs
+---
+
+TODO port over https://www.repronim.org/about_us.html
+Meet the ReproNim Team!
+              	ReproNim Leadership
+              	Our Current Full Team by Site
+              	Directory (gallery)
+
+

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -2,7 +2,10 @@
 # changeLanguage: "Change language"
 # changeTheme: "Change theme"
 # copyCode: "Copy code"
-copyright: "© 2024 ReproNIM Project"
+copyright: |
+  © 2024 ReproNIM Project
+  </br>
+  Grant Support: [NIH-NIBIB P41 EB019936](https://projectreporter.nih.gov/project_info_description.cfm?aid=8999833)
 # dark: "Dark"
 # editThisPage: "Edit this page on GitHub →"
 # lastUpdated: "Last updated on"


### PR DESCRIPTION
Fixes https://github.com/ReproNim/repronim.org/issues/51

@juliebates I made a few modifications, please let me know if anything isnt 

For the pages will be ported, I've filed a separate issue for each: 
 - https://github.com/ReproNim/repronim.org/issues/56
 - https://github.com/ReproNim/repronim.org/issues/57
 - https://github.com/ReproNim/repronim.org/issues/58
 
Since the subpages of about us show up on the left side, I thought it seemed a bit redundant to put eab, collaborators, and team in the about_us text, only to link to the same place. 
![image](https://github.com/user-attachments/assets/48a89713-8b38-496f-a936-c0ed37a001aa)

I've put the grant id into the footer for all pages (I linked it to the same link as the , I don't think we can modify the footer for a single page 
![image](https://github.com/user-attachments/assets/ed7ec9a8-0669-43fd-b235-e2ead296203e)
