### PR TITLE
Convert publications static page into "taxonomies"

### DIFF
--- a/content/authors/_index.md
+++ b/content/authors/_index.md
@@ -1,0 +1,5 @@
+---
+title: Authors of ReproNim and related publications
+ordersectionsby: title
+---
+

--- a/content/publications/abrams-2021/cite.bib
+++ b/content/publications/abrams-2021/cite.bib
@@ -1,0 +1,23 @@
+@article{abrams_2021,
+ author = {Abrams, Mathew Birdsall and Bjaalie, Jan G. and Das, Samir
+and Egan, Gary F. and Ghosh, Satrajit S. and Goscinski,
+Wojtek J. and Grethe, Jeffrey S. and Kotaleski, Jeanette
+Hellgren and Ho, Eric Tatt Wei and Kennedy, David N. and
+Lanyon, Linda J. and Leergaard, Trygve B. and Mayberg,
+Helen S. and Milanesi, Luciano and Mouček, Roman and
+Poline, J. B. and Roy, Prasun K. and Strother, Stephen C.
+and Tang, Tong Boon and Tiesinga, Paul and Wachtler, Thomas
+and Wójcik, Daniel K. and Martone, Maryann E.},
+ doi = {10.1007/s12021-020-09509-0},
+ issn = {1559-0089},
+ journal = {Neuroinformatics},
+ month = {January},
+ number = {1},
+ pages = {25–36},
+ publisher = {Springer Science and Business Media LLC},
+ title = {A Standards Organization for Open and FAIR Neuroscience:
+the International Neuroinformatics Coordinating Facility},
+ url = {http://dx.doi.org/10.1007/s12021-020-09509-0},
+ volume = {20},
+ year = {2021}
+}

--- a/content/publications/abrams-2021/index.md
+++ b/content/publications/abrams-2021/index.md
@@ -1,0 +1,37 @@
+---
+title: 'A Standards Organization for Open and FAIR Neuroscience: the International
+  Neuroinformatics Coordinating Facility'
+authors:
+- Mathew Birdsall Abrams
+- Jan G. Bjaalie
+- Samir Das
+- Gary F. Egan
+- Satrajit S. Ghosh
+- Wojtek J. Goscinski
+- Jeffrey S. Grethe
+- Jeanette Hellgren Kotaleski
+- Eric Tatt Wei Ho
+- David N. Kennedy
+- Linda J. Lanyon
+- Trygve B. Leergaard
+- Helen S. Mayberg
+- Luciano Milanesi
+- Roman Mouček
+- J. B. Poline
+- Prasun K. Roy
+- Stephen C. Strother
+- Tong Boon Tang
+- Paul Tiesinga
+- Thomas Wachtler
+- Daniel K. Wójcik
+- Maryann E. Martone
+date: '2021-01-01'
+publishDate: '2024-12-19T23:16:36.346376Z'
+publication_types:
+- article-journal
+publication: '*Neuroinformatics*'
+doi: 10.1007/s12021-020-09509-0
+links:
+- name: URL
+  url: http://dx.doi.org/10.1007/s12021-020-09509-0
+---

--- a/content/publications/bandrowski-2016/cite.bib
+++ b/content/publications/bandrowski-2016/cite.bib
@@ -1,0 +1,15 @@
+@article{bandrowski_2016,
+ author = {Bandrowski, Anita E. and Martone, Maryann E.},
+ doi = {10.1016/j.neuron.2016.04.030},
+ issn = {0896-6273},
+ journal = {Neuron},
+ month = {May},
+ number = {3},
+ pages = {434–436},
+ publisher = {Elsevier BV},
+ title = {RRIDs: A Simple Step toward Improving Reproducibility
+through Rigor and Transparency of Experimental Methods},
+ url = {http://dx.doi.org/10.1016/j.neuron.2016.04.030},
+ volume = {90},
+ year = {2016}
+}

--- a/content/publications/bandrowski-2016/index.md
+++ b/content/publications/bandrowski-2016/index.md
@@ -1,0 +1,16 @@
+---
+title: 'RRIDs: A Simple Step toward Improving Reproducibility through Rigor and Transparency
+  of Experimental Methods'
+authors:
+- Anita E. Bandrowski
+- Maryann E. Martone
+date: '2016-05-01'
+publishDate: '2024-12-19T23:16:36.352565Z'
+publication_types:
+- article-journal
+publication: '*Neuron*'
+doi: 10.1016/j.neuron.2016.04.030
+links:
+- name: URL
+  url: http://dx.doi.org/10.1016/j.neuron.2016.04.030
+---

--- a/content/publications/bannier-2021/cite.bib
+++ b/content/publications/bannier-2021/cite.bib
@@ -1,0 +1,29 @@
+@article{bannier_2021,
+ author = {Bannier, Elise and Barker, Gareth and Borghesani,
+Valentina and Broeckx, Nils and Clement, Patricia and
+Emblem, Kyrre E. and Ghosh, Satrajit and Glerean, Enrico
+and Gorgolewski, Krzysztof J. and Havu, Marko and
+Halchenko, Yaroslav O. and Herholz, Peer and Hespel, Anne
+and Heunis, Stephan and Hu, Yue and Hu, Chuan‐Peng and
+Huijser, Dorien and de la Iglesia Vayá, María and
+Jancalek, Radim and Katsaros, Vasileios K. and Kieseler,
+Marie‐Luise and Maumet, Camille and Moreau, Clara A. and
+Mutsaerts, Henk‐Jan and Oostenveld, Robert and
+Ozturk‐Isik, Esin and Pascual Leone Espinosa, Nicolas and
+Pellman, John and Pernet, Cyril R and Pizzini, Francesca
+Benedetta and Trbalić, Amira Šerifović and Toussaint,
+Paule‐Joanne and Visconti di Oleggio Castello, Matteo and
+Wang, Fengjuan and Wang, Cheng and Zhu, Hua},
+ doi = {10.1002/hbm.25351},
+ issn = {1097-0193},
+ journal = {Human Brain Mapping},
+ month = {February},
+ number = {7},
+ pages = {1945–1951},
+ publisher = {Wiley},
+ title = {The Open Brain Consent: Informing research participants
+and obtaining consent to share brain imaging data},
+ url = {http://dx.doi.org/10.1002/hbm.25351},
+ volume = {42},
+ year = {2021}
+}

--- a/content/publications/bannier-2021/index.md
+++ b/content/publications/bannier-2021/index.md
@@ -1,0 +1,50 @@
+---
+title: 'The Open Brain Consent: Informing research participants and obtaining consent
+  to share brain imaging data'
+authors:
+- Elise Bannier
+- Gareth Barker
+- Valentina Borghesani
+- Nils Broeckx
+- Patricia Clement
+- Kyrre E. Emblem
+- Satrajit Ghosh
+- Enrico Glerean
+- Krzysztof J. Gorgolewski
+- Marko Havu
+- Yaroslav O. Halchenko
+- Peer Herholz
+- Anne Hespel
+- Stephan Heunis
+- Yue Hu
+- Chuan‐Peng Hu
+- Dorien Huijser
+- María de la Iglesia Vayá
+- Radim Jancalek
+- Vasileios K. Katsaros
+- Marie‐Luise Kieseler
+- Camille Maumet
+- Clara A. Moreau
+- Henk‐Jan Mutsaerts
+- Robert Oostenveld
+- Esin Ozturk‐Isik
+- Nicolas Pascual Leone Espinosa
+- John Pellman
+- Cyril R Pernet
+- Francesca Benedetta Pizzini
+- Amira Šerifović Trbalić
+- Paule‐Joanne Toussaint
+- Matteo Visconti di Oleggio Castello
+- Fengjuan Wang
+- Cheng Wang
+- Hua Zhu
+date: '2021-02-01'
+publishDate: '2024-12-19T23:16:36.356531Z'
+publication_types:
+- article-journal
+publication: '*Human Brain Mapping*'
+doi: 10.1002/hbm.25351
+links:
+- name: URL
+  url: http://dx.doi.org/10.1002/hbm.25351
+---

--- a/content/publications/baranger-2021/cite.bib
+++ b/content/publications/baranger-2021/cite.bib
@@ -1,0 +1,15 @@
+@article{baranger_2021,
+ author = {Baranger, David A.A. and Halchenko, Yaroslav O. and Satz,
+Skye and Ragozzino, Rachel and Iyengar, Satish and Swartz,
+Holly A. and Manelis, Anna},
+ doi = {10.1016/j.mex.2021.101595},
+ issn = {2215-0161},
+ journal = {MethodsX},
+ pages = {101595},
+ publisher = {Elsevier BV},
+ title = {Protocol for a machine learning algorithm predicting
+depressive disorders using the T1w/T2w ratio},
+ url = {http://dx.doi.org/10.1016/j.mex.2021.101595},
+ volume = {8},
+ year = {2021}
+}

--- a/content/publications/baranger-2021/index.md
+++ b/content/publications/baranger-2021/index.md
@@ -1,0 +1,21 @@
+---
+title: Protocol for a machine learning algorithm predicting depressive disorders using
+  the T1w/T2w ratio
+authors:
+- David A.A. Baranger
+- Yaroslav O. Halchenko
+- Skye Satz
+- Rachel Ragozzino
+- Satish Iyengar
+- Holly A. Swartz
+- Anna Manelis
+date: '2021-01-01'
+publishDate: '2024-12-19T23:16:36.361403Z'
+publication_types:
+- article-journal
+publication: '*MethodsX*'
+doi: 10.1016/j.mex.2021.101595
+links:
+- name: URL
+  url: http://dx.doi.org/10.1016/j.mex.2021.101595
+---

--- a/content/publications/bazeille-2021/cite.bib
+++ b/content/publications/bazeille-2021/cite.bib
@@ -1,0 +1,15 @@
+@article{bazeille_2021,
+ author = {Bazeille, Thomas and DuPre, Elizabeth and Richard, Hugo
+and Poline, Jean-Baptiste and Thirion, Bertrand},
+ doi = {10.1016/j.neuroimage.2021.118683},
+ issn = {1053-8119},
+ journal = {NeuroImage},
+ month = {December},
+ pages = {118683},
+ publisher = {Elsevier BV},
+ title = {An empirical evaluation of functional alignment using
+inter-subject decoding},
+ url = {http://dx.doi.org/10.1016/j.neuroimage.2021.118683},
+ volume = {245},
+ year = {2021}
+}

--- a/content/publications/bazeille-2021/index.md
+++ b/content/publications/bazeille-2021/index.md
@@ -1,0 +1,18 @@
+---
+title: An empirical evaluation of functional alignment using inter-subject decoding
+authors:
+- Thomas Bazeille
+- Elizabeth DuPre
+- Hugo Richard
+- Jean-Baptiste Poline
+- Bertrand Thirion
+date: '2021-12-01'
+publishDate: '2024-12-19T23:16:36.365494Z'
+publication_types:
+- article-journal
+publication: '*NeuroImage*'
+doi: 10.1016/j.neuroimage.2021.118683
+links:
+- name: URL
+  url: http://dx.doi.org/10.1016/j.neuroimage.2021.118683
+---

--- a/content/publications/bhagwat-2021/cite.bib
+++ b/content/publications/bhagwat-2021/cite.bib
@@ -1,0 +1,18 @@
+@article{bhagwat_2021,
+ author = {Bhagwat, Nikhil and Barry, Amadou and Dickie, Erin W and
+Brown, Shawn T and Devenyi, Gabriel A and Hatano, Koji and
+DuPre, Elizabeth and Dagher, Alain and Chakravarty, Mallar
+and Greenwood, Celia M T and Misic, Bratislav and Kennedy,
+David N and Poline, Jean-Baptiste},
+ doi = {10.1093/gigascience/giaa155},
+ issn = {2047-217X},
+ journal = {GigaScience},
+ month = {January},
+ number = {1},
+ publisher = {Oxford University Press (OUP)},
+ title = {Understanding the impact of preprocessing pipelines on
+neuroimaging cortical surface analyses},
+ url = {http://dx.doi.org/10.1093/gigascience/giaa155},
+ volume = {10},
+ year = {2021}
+}

--- a/content/publications/bhagwat-2021/index.md
+++ b/content/publications/bhagwat-2021/index.md
@@ -1,0 +1,27 @@
+---
+title: Understanding the impact of preprocessing pipelines on neuroimaging cortical
+  surface analyses
+authors:
+- Nikhil Bhagwat
+- Amadou Barry
+- Erin W Dickie
+- Shawn T Brown
+- Gabriel A Devenyi
+- Koji Hatano
+- Elizabeth DuPre
+- Alain Dagher
+- Mallar Chakravarty
+- Celia M T Greenwood
+- Bratislav Misic
+- David N Kennedy
+- Jean-Baptiste Poline
+date: '2021-01-01'
+publishDate: '2024-12-19T23:16:36.369515Z'
+publication_types:
+- article-journal
+publication: '*GigaScience*'
+doi: 10.1093/gigascience/giaa155
+links:
+- name: URL
+  url: http://dx.doi.org/10.1093/gigascience/giaa155
+---

--- a/content/publications/boaro-2022/cite.bib
+++ b/content/publications/boaro-2022/cite.bib
@@ -1,0 +1,19 @@
+@article{boaro_2022,
+ author = {Boaro, Alessandro and Kaczmarzyk, Jakub R. and Kavouridis,
+Vasileios K. and Harary, Maya and Mammi, Marco and Dawood,
+Hassan and Shea, Alice and Cho, Elise Y. and Juvekar,
+Parikshit and Noh, Thomas and Rana, Aakanksha and Ghosh,
+Satrajit and Arnaout, Omar},
+ doi = {10.1038/s41598-022-19356-5},
+ issn = {2045-2322},
+ journal = {Scientific Reports},
+ month = {September},
+ number = {1},
+ publisher = {Springer Science and Business Media LLC},
+ title = {Deep neural networks allow expert-level brain meningioma
+segmentation and present potential for improvement of
+clinical practice},
+ url = {http://dx.doi.org/10.1038/s41598-022-19356-5},
+ volume = {12},
+ year = {2022}
+}

--- a/content/publications/boaro-2022/index.md
+++ b/content/publications/boaro-2022/index.md
@@ -1,0 +1,27 @@
+---
+title: Deep neural networks allow expert-level brain meningioma segmentation and present
+  potential for improvement of clinical practice
+authors:
+- Alessandro Boaro
+- Jakub R. Kaczmarzyk
+- Vasileios K. Kavouridis
+- Maya Harary
+- Marco Mammi
+- Hassan Dawood
+- Alice Shea
+- Elise Y. Cho
+- Parikshit Juvekar
+- Thomas Noh
+- Aakanksha Rana
+- Satrajit Ghosh
+- Omar Arnaout
+date: '2022-09-01'
+publishDate: '2024-12-19T23:16:36.373740Z'
+publication_types:
+- article-journal
+publication: '*Scientific Reports*'
+doi: 10.1038/s41598-022-19356-5
+links:
+- name: URL
+  url: http://dx.doi.org/10.1038/s41598-022-19356-5
+---

--- a/content/publications/bollmann-2023/cite.bib
+++ b/content/publications/bollmann-2023/cite.bib
@@ -1,0 +1,26 @@
+@article{bollmann_2023,
+ author = {Bollmann, Steffen and Renton, Angela and Dao, Thuy and
+Johnstone, Tom and Civier, Oren and Sullivan, Ryan and
+White, David and Lyons, Paris and Slade, Benjamin and
+Abbott, David and Amos, Toluwani and Bollmann, Saskia and
+Botting, Andy and Campbell, Megan and Chang, Jeryn and
+Close, Thomas and Eckstein, Korbinian and Egan, Gary and
+Evas, Stefanie and Flandin, Guillaume and Garner, Kelly and
+Garrido, Marta and Ghosh, Satrajit and Grignard, Martin and
+Hannan, Anthony and Huber, Laurentius (Renzo) and
+Kaczmarzyk, Jakub and Kasper, Lars and Kuhlmann, Levin and
+Lou, Kexin and Mantilla-Ramos, Yorguin-Jose and Mattingley,
+Jason and Morris, Jo and Narayanan, Akshaiy and Pestilli,
+Franco and Puce, Aina and Ribeiro, Fernanda and Rogasch,
+Nigel and Rorden, Chris and Schira, Mark and Shaw, Thomas
+and Sowman, Paul and Spitz, Gershon and Stewart, Ashley and
+Ye, Xincheng and Zhu, Judy and Hughes, Matthew and
+Narayanan, Aswin},
+ doi = {10.21203/rs.3.rs-2649734/v1},
+ month = {March},
+ publisher = {Research Square Platform LLC},
+ title = {Neurodesk: An accessible, flexible, and portable data
+analysis environment for reproducible neuroimaging},
+ url = {http://dx.doi.org/10.21203/rs.3.rs-2649734/v1},
+ year = {2023}
+}

--- a/content/publications/bollmann-2023/index.md
+++ b/content/publications/bollmann-2023/index.md
@@ -1,0 +1,62 @@
+---
+title: 'Neurodesk: An accessible, flexible, and portable data analysis environment
+  for reproducible neuroimaging'
+authors:
+- Steffen Bollmann
+- Angela Renton
+- Thuy Dao
+- Tom Johnstone
+- Oren Civier
+- Ryan Sullivan
+- David White
+- Paris Lyons
+- Benjamin Slade
+- David Abbott
+- Toluwani Amos
+- Saskia Bollmann
+- Andy Botting
+- Megan Campbell
+- Jeryn Chang
+- Thomas Close
+- Korbinian Eckstein
+- Gary Egan
+- Stefanie Evas
+- Guillaume Flandin
+- Kelly Garner
+- Marta Garrido
+- Satrajit Ghosh
+- Martin Grignard
+- Anthony Hannan
+- Laurentius (Renzo) Huber
+- Jakub Kaczmarzyk
+- Lars Kasper
+- Levin Kuhlmann
+- Kexin Lou
+- Yorguin-Jose Mantilla-Ramos
+- Jason Mattingley
+- Jo Morris
+- Akshaiy Narayanan
+- Franco Pestilli
+- Aina Puce
+- Fernanda Ribeiro
+- Nigel Rogasch
+- Chris Rorden
+- Mark Schira
+- Thomas Shaw
+- Paul Sowman
+- Gershon Spitz
+- Ashley Stewart
+- Xincheng Ye
+- Judy Zhu
+- Matthew Hughes
+- Aswin Narayanan
+date: '2023-03-01'
+publishDate: '2024-12-19T23:16:36.377908Z'
+publication_types:
+- article-journal
+publication: '*Research Square Platform LLC*'
+doi: 10.21203/rs.3.rs-2649734/v1
+links:
+- name: URL
+  url: http://dx.doi.org/10.21203/rs.3.rs-2649734/v1
+---

--- a/content/publications/botvinik-nezer-2020/cite.bib
+++ b/content/publications/botvinik-nezer-2020/cite.bib
@@ -1,0 +1,90 @@
+@article{botvinik_nezer_2020,
+ author = {Botvinik-Nezer, Rotem and Holzmeister, Felix and Camerer,
+Colin F. and Dreber, Anna and Huber, Juergen and
+Johannesson, Magnus and Kirchler, Michael and Iwanir, Roni
+and Mumford, Jeanette A. and Adcock, R. Alison and Avesani,
+Paolo and Baczkowski, Blazej M. and Bajracharya, Aahana and
+Bakst, Leah and Ball, Sheryl and Barilari, Marco and Bault,
+Nadège and Beaton, Derek and Beitner, Julia and Benoit,
+Roland G. and Berkers, Ruud M. W. J. and Bhanji, Jamil P.
+and Biswal, Bharat B. and Bobadilla-Suarez, Sebastian and
+Bortolini, Tiago and Bottenhorn, Katherine L. and Bowring,
+Alexander and Braem, Senne and Brooks, Hayley R. and
+Brudner, Emily G. and Calderon, Cristian B. and Camilleri,
+Julia A. and Castrellon, Jaime J. and Cecchetti, Luca and
+Cieslik, Edna C. and Cole, Zachary J. and Collignon,
+Olivier and Cox, Robert W. and Cunningham, William A. and
+Czoschke, Stefan and Dadi, Kamalaker and Davis, Charles P.
+and Luca, Alberto De and Delgado, Mauricio R. and
+Demetriou, Lysia and Dennison, Jeffrey B. and Di, Xin and
+Dickie, Erin W. and Dobryakova, Ekaterina and Donnat,
+Claire L. and Dukart, Juergen and Duncan, Niall W. and
+Durnez, Joke and Eed, Amr and Eickhoff, Simon B. and
+Erhart, Andrew and Fontanesi, Laura and Fricke, G. Matthew
+and Fu, Shiguang and Galván, Adriana and Gau, Remi and
+Genon, Sarah and Glatard, Tristan and Glerean, Enrico and
+Goeman, Jelle J. and Golowin, Sergej A. E. and
+González-García, Carlos and Gorgolewski, Krzysztof J. and
+Grady, Cheryl L. and Green, Mikella A. and Guassi Moreira,
+João F. and Guest, Olivia and Hakimi, Shabnam and
+Hamilton, J. Paul and Hancock, Roeland and Handjaras,
+Giacomo and Harry, Bronson B. and Hawco, Colin and Herholz,
+Peer and Herman, Gabrielle and Heunis, Stephan and
+Hoffstaedter, Felix and Hogeveen, Jeremy and Holmes, Susan
+and Hu, Chuan-Peng and Huettel, Scott A. and Hughes,
+Matthew E. and Iacovella, Vittorio and Iordan, Alexandru D.
+and Isager, Peder M. and Isik, Ayse I. and Jahn, Andrew and
+Johnson, Matthew R. and Johnstone, Tom and Joseph, Michael
+J. E. and Juliano, Anthony C. and Kable, Joseph W. and
+Kassinopoulos, Michalis and Koba, Cemal and Kong,
+Xiang-Zhen and Koscik, Timothy R. and Kucukboyaci, Nuri
+Erkut and Kuhl, Brice A. and Kupek, Sebastian and Laird,
+Angela R. and Lamm, Claus and Langner, Robert and
+Lauharatanahirun, Nina and Lee, Hongmi and Lee, Sangil and
+Leemans, Alexander and Leo, Andrea and Lesage, Elise and
+Li, Flora and Li, Monica Y. C. and Lim, Phui Cheng and
+Lintz, Evan N. and Liphardt, Schuyler W. and Losecaat
+Vermeer, Annabel B. and Love, Bradley C. and Mack, Michael
+L. and Malpica, Norberto and Marins, Theo and Maumet,
+Camille and McDonald, Kelsey and McGuire, Joseph T. and
+Melero, Helena and Méndez Leal, Adriana S. and Meyer,
+Benjamin and Meyer, Kristin N. and Mihai, Glad and Mitsis,
+Georgios D. and Moll, Jorge and Nielson, Dylan M. and
+Nilsonne, Gustav and Notter, Michael P. and Olivetti,
+Emanuele and Onicas, Adrian I. and Papale, Paolo and Patil,
+Kaustubh R. and Peelle, Jonathan E. and Pérez, Alexandre
+and Pischedda, Doris and Poline, Jean-Baptiste and
+Prystauka, Yanina and Ray, Shruti and Reuter-Lorenz,
+Patricia A. and Reynolds, Richard C. and Ricciardi,
+Emiliano and Rieck, Jenny R. and Rodriguez-Thompson, Anais
+M. and Romyn, Anthony and Salo, Taylor and Samanez-Larkin,
+Gregory R. and Sanz-Morales, Emilio and Schlichting,
+Margaret L. and Schultz, Douglas H. and Shen, Qiang and
+Sheridan, Margaret A. and Silvers, Jennifer A. and
+Skagerlund, Kenny and Smith, Alec and Smith, David V. and
+Sokol-Hessner, Peter and Steinkamp, Simon R. and Tashjian,
+Sarah M. and Thirion, Bertrand and Thorp, John N. and
+Tinghög, Gustav and Tisdall, Loreen and Tompson, Steven H.
+and Toro-Serey, Claudio and Torre Tresols, Juan Jesus and
+Tozzi, Leonardo and Truong, Vuong and Turella, Luca and van
+‘t Veer, Anna E. and Verguts, Tom and Vettel, Jean M. and
+Vijayarajah, Sagana and Vo, Khoi and Wall, Matthew B. and
+Weeda, Wouter D. and Weis, Susanne and White, David J. and
+Wisniewski, David and Xifra-Porxas, Alba and Yearling,
+Emily A. and Yoon, Sangsuk and Yuan, Rui and Yuen, Kenneth
+S. L. and Zhang, Lei and Zhang, Xu and Zosky, Joshua E. and
+Nichols, Thomas E. and Poldrack, Russell A. and Schonberg,
+Tom},
+ doi = {10.1038/s41586-020-2314-9},
+ issn = {1476-4687},
+ journal = {Nature},
+ month = {May},
+ number = {7810},
+ pages = {84–88},
+ publisher = {Springer Science and Business Media LLC},
+ title = {Variability in the analysis of a single neuroimaging
+dataset by many teams},
+ url = {http://dx.doi.org/10.1038/s41586-020-2314-9},
+ volume = {582},
+ year = {2020}
+}

--- a/content/publications/botvinik-nezer-2020/index.md
+++ b/content/publications/botvinik-nezer-2020/index.md
@@ -1,0 +1,210 @@
+---
+title: Variability in the analysis of a single neuroimaging dataset by many teams
+authors:
+- Rotem Botvinik-Nezer
+- Felix Holzmeister
+- Colin F. Camerer
+- Anna Dreber
+- Juergen Huber
+- Magnus Johannesson
+- Michael Kirchler
+- Roni Iwanir
+- Jeanette A. Mumford
+- R. Alison Adcock
+- Paolo Avesani
+- Blazej M. Baczkowski
+- Aahana Bajracharya
+- Leah Bakst
+- Sheryl Ball
+- Marco Barilari
+- Nadège Bault
+- Derek Beaton
+- Julia Beitner
+- Roland G. Benoit
+- Ruud M. W. J. Berkers
+- Jamil P. Bhanji
+- Bharat B. Biswal
+- Sebastian Bobadilla-Suarez
+- Tiago Bortolini
+- Katherine L. Bottenhorn
+- Alexander Bowring
+- Senne Braem
+- Hayley R. Brooks
+- Emily G. Brudner
+- Cristian B. Calderon
+- Julia A. Camilleri
+- Jaime J. Castrellon
+- Luca Cecchetti
+- Edna C. Cieslik
+- Zachary J. Cole
+- Olivier Collignon
+- Robert W. Cox
+- William A. Cunningham
+- Stefan Czoschke
+- Kamalaker Dadi
+- Charles P. Davis
+- Alberto De Luca
+- Mauricio R. Delgado
+- Lysia Demetriou
+- Jeffrey B. Dennison
+- Xin Di
+- Erin W. Dickie
+- Ekaterina Dobryakova
+- Claire L. Donnat
+- Juergen Dukart
+- Niall W. Duncan
+- Joke Durnez
+- Amr Eed
+- Simon B. Eickhoff
+- Andrew Erhart
+- Laura Fontanesi
+- G. Matthew Fricke
+- Shiguang Fu
+- Adriana Galván
+- Remi Gau
+- Sarah Genon
+- Tristan Glatard
+- Enrico Glerean
+- Jelle J. Goeman
+- Sergej A. E. Golowin
+- Carlos González-García
+- Krzysztof J. Gorgolewski
+- Cheryl L. Grady
+- Mikella A. Green
+- João F. Guassi Moreira
+- Olivia Guest
+- Shabnam Hakimi
+- J. Paul Hamilton
+- Roeland Hancock
+- Giacomo Handjaras
+- Bronson B. Harry
+- Colin Hawco
+- Peer Herholz
+- Gabrielle Herman
+- Stephan Heunis
+- Felix Hoffstaedter
+- Jeremy Hogeveen
+- Susan Holmes
+- Chuan-Peng Hu
+- Scott A. Huettel
+- Matthew E. Hughes
+- Vittorio Iacovella
+- Alexandru D. Iordan
+- Peder M. Isager
+- Ayse I. Isik
+- Andrew Jahn
+- Matthew R. Johnson
+- Tom Johnstone
+- Michael J. E. Joseph
+- Anthony C. Juliano
+- Joseph W. Kable
+- Michalis Kassinopoulos
+- Cemal Koba
+- Xiang-Zhen Kong
+- Timothy R. Koscik
+- Nuri Erkut Kucukboyaci
+- Brice A. Kuhl
+- Sebastian Kupek
+- Angela R. Laird
+- Claus Lamm
+- Robert Langner
+- Nina Lauharatanahirun
+- Hongmi Lee
+- Sangil Lee
+- Alexander Leemans
+- Andrea Leo
+- Elise Lesage
+- Flora Li
+- Monica Y. C. Li
+- Phui Cheng Lim
+- Evan N. Lintz
+- Schuyler W. Liphardt
+- Annabel B. Losecaat Vermeer
+- Bradley C. Love
+- Michael L. Mack
+- Norberto Malpica
+- Theo Marins
+- Camille Maumet
+- Kelsey McDonald
+- Joseph T. McGuire
+- Helena Melero
+- Adriana S. Méndez Leal
+- Benjamin Meyer
+- Kristin N. Meyer
+- Glad Mihai
+- Georgios D. Mitsis
+- Jorge Moll
+- Dylan M. Nielson
+- Gustav Nilsonne
+- Michael P. Notter
+- Emanuele Olivetti
+- Adrian I. Onicas
+- Paolo Papale
+- Kaustubh R. Patil
+- Jonathan E. Peelle
+- Alexandre Pérez
+- Doris Pischedda
+- Jean-Baptiste Poline
+- Yanina Prystauka
+- Shruti Ray
+- Patricia A. Reuter-Lorenz
+- Richard C. Reynolds
+- Emiliano Ricciardi
+- Jenny R. Rieck
+- Anais M. Rodriguez-Thompson
+- Anthony Romyn
+- Taylor Salo
+- Gregory R. Samanez-Larkin
+- Emilio Sanz-Morales
+- Margaret L. Schlichting
+- Douglas H. Schultz
+- Qiang Shen
+- Margaret A. Sheridan
+- Jennifer A. Silvers
+- Kenny Skagerlund
+- Alec Smith
+- David V. Smith
+- Peter Sokol-Hessner
+- Simon R. Steinkamp
+- Sarah M. Tashjian
+- Bertrand Thirion
+- John N. Thorp
+- Gustav Tinghög
+- Loreen Tisdall
+- Steven H. Tompson
+- Claudio Toro-Serey
+- Juan Jesus Torre Tresols
+- Leonardo Tozzi
+- Vuong Truong
+- Luca Turella
+- Anna E. van ‘t Veer
+- Tom Verguts
+- Jean M. Vettel
+- Sagana Vijayarajah
+- Khoi Vo
+- Matthew B. Wall
+- Wouter D. Weeda
+- Susanne Weis
+- David J. White
+- David Wisniewski
+- Alba Xifra-Porxas
+- Emily A. Yearling
+- Sangsuk Yoon
+- Rui Yuan
+- Kenneth S. L. Yuen
+- Lei Zhang
+- Xu Zhang
+- Joshua E. Zosky
+- Thomas E. Nichols
+- Russell A. Poldrack
+- Tom Schonberg
+date: '2020-05-01'
+publishDate: '2024-12-19T23:16:36.382775Z'
+publication_types:
+- article-journal
+publication: '*Nature*'
+doi: 10.1038/s41586-020-2314-9
+links:
+- name: URL
+  url: http://dx.doi.org/10.1038/s41586-020-2314-9
+---

--- a/content/publications/burdinski-2024/cite.bib
+++ b/content/publications/burdinski-2024/cite.bib
@@ -1,0 +1,12 @@
+@article{burdinski_2024,
+ author = {Burdinski, Debbie and Kodibagkar, Alisha and Potter, Kevin
+and Schuster, Randi and Evins, A. Eden and Ghosh, Satrajit
+and Gilman, Jodi},
+ doi = {10.1101/2024.04.29.24306516},
+ month = {May},
+ publisher = {Cold Spring Harbor Laboratory},
+ title = {Impact of year-long cannabis use for medical symptoms on
+brain activation during cognitive processes},
+ url = {http://dx.doi.org/10.1101/2024.04.29.24306516},
+ year = {2024}
+}

--- a/content/publications/burdinski-2024/index.md
+++ b/content/publications/burdinski-2024/index.md
@@ -1,0 +1,21 @@
+---
+title: Impact of year-long cannabis use for medical symptoms on brain activation during
+  cognitive processes
+authors:
+- Debbie Burdinski
+- Alisha Kodibagkar
+- Kevin Potter
+- Randi Schuster
+- A. Eden Evins
+- Satrajit Ghosh
+- Jodi Gilman
+date: '2024-05-01'
+publishDate: '2024-12-19T23:16:36.390525Z'
+publication_types:
+- article-journal
+publication: '*Cold Spring Harbor Laboratory*'
+doi: 10.1101/2024.04.29.24306516
+links:
+- name: URL
+  url: http://dx.doi.org/10.1101/2024.04.29.24306516
+---

--- a/content/publications/charles-2020/cite.bib
+++ b/content/publications/charles-2020/cite.bib
@@ -1,0 +1,19 @@
+@article{charles_2020,
+ author = {Charles, Adam S. and Falk, Benjamin and Turner, Nicholas
+and Pereira, Talmo D. and Tward, Daniel and Pedigo,
+Benjamin D. and Chung, Jaewon and Burns, Randal and Ghosh,
+Satrajit S. and Kebschull, Justus M. and Silversmith,
+William and Vogelstein, Joshua T.},
+ doi = {10.1146/annurev-neuro-100119-110036},
+ issn = {1545-4126},
+ journal = {Annual Review of Neuroscience},
+ month = {July},
+ number = {1},
+ pages = {441–464},
+ publisher = {Annual Reviews},
+ title = {Toward Community-Driven Big Open Brain Science: Open Big
+Data and Tools for Structure, Function, and Genetics},
+ url = {http://dx.doi.org/10.1146/annurev-neuro-100119-110036},
+ volume = {43},
+ year = {2020}
+}

--- a/content/publications/charles-2020/index.md
+++ b/content/publications/charles-2020/index.md
@@ -1,0 +1,26 @@
+---
+title: 'Toward Community-Driven Big Open Brain Science: Open Big Data and Tools for
+  Structure, Function, and Genetics'
+authors:
+- Adam S. Charles
+- Benjamin Falk
+- Nicholas Turner
+- Talmo D. Pereira
+- Daniel Tward
+- Benjamin D. Pedigo
+- Jaewon Chung
+- Randal Burns
+- Satrajit S. Ghosh
+- Justus M. Kebschull
+- William Silversmith
+- Joshua T. Vogelstein
+date: '2020-07-01'
+publishDate: '2024-12-19T23:16:36.394656Z'
+publication_types:
+- article-journal
+publication: '*Annual Review of Neuroscience*'
+doi: 10.1146/annurev-neuro-100119-110036
+links:
+- name: URL
+  url: http://dx.doi.org/10.1146/annurev-neuro-100119-110036
+---

--- a/content/publications/cheng-2020/cite.bib
+++ b/content/publications/cheng-2020/cite.bib
@@ -1,0 +1,14 @@
+@article{cheng_2020,
+ author = {Cheng, Christopher P. and Halchenko, Yaroslav O.},
+ doi = {10.12688/f1000research.24544.1},
+ issn = {2046-1402},
+ journal = {F1000Research},
+ month = {September},
+ pages = {1131},
+ publisher = {F1000 Research Ltd},
+ title = {A new virtue of phantom MRI data: explaining variance in
+human participant data},
+ url = {http://dx.doi.org/10.12688/f1000research.24544.1},
+ volume = {9},
+ year = {2020}
+}

--- a/content/publications/cheng-2020/index.md
+++ b/content/publications/cheng-2020/index.md
@@ -1,0 +1,16 @@
+---
+title: 'A new virtue of phantom MRI data: explaining variance in human participant
+  data'
+authors:
+- Christopher P. Cheng
+- Yaroslav O. Halchenko
+date: '2020-09-01'
+publishDate: '2024-12-19T23:16:36.398756Z'
+publication_types:
+- article-journal
+publication: '*F1000Research*'
+doi: 10.12688/f1000research.24544.1
+links:
+- name: URL
+  url: http://dx.doi.org/10.12688/f1000research.24544.1
+---

--- a/content/publications/ciric-2022/cite.bib
+++ b/content/publications/ciric-2022/cite.bib
@@ -1,0 +1,19 @@
+@article{ciric_2022,
+ author = {Ciric, Rastko and Thompson, William H. and Lorenz, Romy
+and Goncalves, Mathias and MacNicol, Eilidh E. and
+Markiewicz, Christopher J. and Halchenko, Yaroslav O. and
+Ghosh, Satrajit S. and Gorgolewski, Krzysztof J. and
+Poldrack, Russell A. and Esteban, Oscar},
+ doi = {10.1038/s41592-022-01681-2},
+ issn = {1548-7105},
+ journal = {Nature Methods},
+ month = {December},
+ number = {12},
+ pages = {1568–1571},
+ publisher = {Springer Science and Business Media LLC},
+ title = {TemplateFlow: FAIR-sharing of multi-scale, multi-species
+brain models},
+ url = {http://dx.doi.org/10.1038/s41592-022-01681-2},
+ volume = {19},
+ year = {2022}
+}

--- a/content/publications/ciric-2022/index.md
+++ b/content/publications/ciric-2022/index.md
@@ -1,0 +1,24 @@
+---
+title: 'TemplateFlow: FAIR-sharing of multi-scale, multi-species brain models'
+authors:
+- Rastko Ciric
+- William H. Thompson
+- Romy Lorenz
+- Mathias Goncalves
+- Eilidh E. MacNicol
+- Christopher J. Markiewicz
+- Yaroslav O. Halchenko
+- Satrajit S. Ghosh
+- Krzysztof J. Gorgolewski
+- Russell A. Poldrack
+- Oscar Esteban
+date: '2022-12-01'
+publishDate: '2024-12-19T23:16:36.402766Z'
+publication_types:
+- article-journal
+publication: '*Nature Methods*'
+doi: 10.1038/s41592-022-01681-2
+links:
+- name: URL
+  url: http://dx.doi.org/10.1038/s41592-022-01681-2
+---

--- a/content/publications/cruces-2022/cite.bib
+++ b/content/publications/cruces-2022/cite.bib
@@ -1,0 +1,20 @@
+@article{cruces_2022,
+ author = {Cruces, Raúl R. and Royer, Jessica and Herholz, Peer and
+Larivière, Sara and Vos de Wael, Reinder and Paquola,
+Casey and Benkarim, Oualid and Park, Bo-yong and
+Degré-Pelletier, Janie and Nelson, Mark C. and DeKraker,
+Jordan and Leppert, Ilana R. and Tardif, Christine and
+Poline, Jean-Baptiste and Concha, Luis and Bernhardt, Boris
+C.},
+ doi = {10.1016/j.neuroimage.2022.119612},
+ issn = {1053-8119},
+ journal = {NeuroImage},
+ month = {November},
+ pages = {119612},
+ publisher = {Elsevier BV},
+ title = {Micapipe: A pipeline for multimodal neuroimaging and
+connectome analysis},
+ url = {http://dx.doi.org/10.1016/j.neuroimage.2022.119612},
+ volume = {263},
+ year = {2022}
+}

--- a/content/publications/cruces-2022/index.md
+++ b/content/publications/cruces-2022/index.md
@@ -1,0 +1,29 @@
+---
+title: 'Micapipe: A pipeline for multimodal neuroimaging and connectome analysis'
+authors:
+- Raúl R. Cruces
+- Jessica Royer
+- Peer Herholz
+- Sara Larivière
+- Reinder Vos de Wael
+- Casey Paquola
+- Oualid Benkarim
+- Bo-yong Park
+- Janie Degré-Pelletier
+- Mark C. Nelson
+- Jordan DeKraker
+- Ilana R. Leppert
+- Christine Tardif
+- Jean-Baptiste Poline
+- Luis Concha
+- Boris C. Bernhardt
+date: '2022-11-01'
+publishDate: '2024-12-19T23:16:36.407061Z'
+publication_types:
+- article-journal
+publication: '*NeuroImage*'
+doi: 10.1016/j.neuroimage.2022.119612
+links:
+- name: URL
+  url: http://dx.doi.org/10.1016/j.neuroimage.2022.119612
+---

--- a/content/publications/de-la-vega-2022/cite.bib
+++ b/content/publications/de-la-vega-2022/cite.bib
@@ -1,0 +1,16 @@
+@article{de_la_vega_2022,
+ author = {de la Vega, Alejandro and Rocca, Roberta and Blair, Ross W
+and Markiewicz, Christopher J and Mentch, Jeff and Kent,
+James D and Herholz, Peer and Ghosh, Satrajit S and
+Poldrack, Russell A and Yarkoni, Tal},
+ doi = {10.7554/elife.79277},
+ issn = {2050-084X},
+ journal = {eLife},
+ month = {August},
+ publisher = {eLife Sciences Publications, Ltd},
+ title = {Neuroscout, a unified platform for generalizable and
+reproducible fMRI research},
+ url = {http://dx.doi.org/10.7554/elife.79277},
+ volume = {11},
+ year = {2022}
+}

--- a/content/publications/de-la-vega-2022/index.md
+++ b/content/publications/de-la-vega-2022/index.md
@@ -1,0 +1,23 @@
+---
+title: Neuroscout, a unified platform for generalizable and reproducible fMRI research
+authors:
+- Alejandro de la Vega
+- Roberta Rocca
+- Ross W Blair
+- Christopher J Markiewicz
+- Jeff Mentch
+- James D Kent
+- Peer Herholz
+- Satrajit S Ghosh
+- Russell A Poldrack
+- Tal Yarkoni
+date: '2022-08-01'
+publishDate: '2024-12-19T23:16:36.411316Z'
+publication_types:
+- article-journal
+publication: '*eLife*'
+doi: 10.7554/elife.79277
+links:
+- name: URL
+  url: http://dx.doi.org/10.7554/elife.79277
+---

--- a/content/publications/dock-s-2021/cite.bib
+++ b/content/publications/dock-s-2021/cite.bib
@@ -1,0 +1,15 @@
+@article{dock_s_2021,
+ author = {Dockès, Jérôme and Varoquaux, Gaël and Poline,
+Jean-Baptiste},
+ doi = {10.1093/gigascience/giab055},
+ issn = {2047-217X},
+ journal = {GigaScience},
+ month = {September},
+ number = {9},
+ publisher = {Oxford University Press (OUP)},
+ title = {Preventing dataset shift from breaking machine-learning
+biomarkers},
+ url = {http://dx.doi.org/10.1093/gigascience/giab055},
+ volume = {10},
+ year = {2021}
+}

--- a/content/publications/dock-s-2021/index.md
+++ b/content/publications/dock-s-2021/index.md
@@ -1,0 +1,16 @@
+---
+title: Preventing dataset shift from breaking machine-learning biomarkers
+authors:
+- Jérôme Dockès
+- Gaël Varoquaux
+- Jean-Baptiste Poline
+date: '2021-09-01'
+publishDate: '2024-12-19T23:16:36.415505Z'
+publication_types:
+- article-journal
+publication: '*GigaScience*'
+doi: 10.1093/gigascience/giab055
+links:
+- name: URL
+  url: http://dx.doi.org/10.1093/gigascience/giab055
+---

--- a/content/publications/dupre-2020/cite.bib
+++ b/content/publications/dupre-2020/cite.bib
@@ -1,0 +1,15 @@
+@article{dupre_2020,
+ author = {DuPre, Elizabeth and Hanke, Michael and Poline,
+Jean-Baptiste},
+ doi = {10.1016/j.neuroimage.2019.116330},
+ issn = {1053-8119},
+ journal = {NeuroImage},
+ month = {August},
+ pages = {116330},
+ publisher = {Elsevier BV},
+ title = {Nature abhors a paywall: How open science can realize the
+potential of naturalistic stimuli},
+ url = {http://dx.doi.org/10.1016/j.neuroimage.2019.116330},
+ volume = {216},
+ year = {2020}
+}

--- a/content/publications/dupre-2020/index.md
+++ b/content/publications/dupre-2020/index.md
@@ -1,0 +1,17 @@
+---
+title: 'Nature abhors a paywall: How open science can realize the potential of naturalistic
+  stimuli'
+authors:
+- Elizabeth DuPre
+- Michael Hanke
+- Jean-Baptiste Poline
+date: '2020-08-01'
+publishDate: '2024-12-19T23:16:36.419456Z'
+publication_types:
+- article-journal
+publication: '*NeuroImage*'
+doi: 10.1016/j.neuroimage.2019.116330
+links:
+- name: URL
+  url: http://dx.doi.org/10.1016/j.neuroimage.2019.116330
+---

--- a/content/publications/dupre-2022/cite.bib
+++ b/content/publications/dupre-2022/cite.bib
@@ -1,0 +1,18 @@
+@article{dupre_2022,
+ author = {DuPre, Elizabeth and Holdgraf, Chris and Karakuzu, Agah
+and Tetrel, Loïc and Bellec, Pierre and Stikov, Nikola and
+Poline, Jean-Baptiste},
+ doi = {10.1371/journal.pcbi.1009651},
+ editor = {Mac Gabhann, Feilim},
+ issn = {1553-7358},
+ journal = {PLOS Computational Biology},
+ month = {January},
+ number = {1},
+ pages = {e1009651},
+ publisher = {Public Library of Science (PLoS)},
+ title = {Beyond advertising: New infrastructures for publishing
+integrated research objects},
+ url = {http://dx.doi.org/10.1371/journal.pcbi.1009651},
+ volume = {18},
+ year = {2022}
+}

--- a/content/publications/dupre-2022/index.md
+++ b/content/publications/dupre-2022/index.md
@@ -1,0 +1,21 @@
+---
+title: 'Beyond advertising: New infrastructures for publishing integrated research
+  objects'
+authors:
+- Elizabeth DuPre
+- Chris Holdgraf
+- Agah Karakuzu
+- Loïc Tetrel
+- Pierre Bellec
+- Nikola Stikov
+- Jean-Baptiste Poline
+date: '2022-01-01'
+publishDate: '2024-12-19T23:16:36.423494Z'
+publication_types:
+- article-journal
+publication: '*PLOS Computational Biology*'
+doi: 10.1371/journal.pcbi.1009651
+links:
+- name: URL
+  url: http://dx.doi.org/10.1371/journal.pcbi.1009651
+---

--- a/content/publications/eglen-2017/cite.bib
+++ b/content/publications/eglen-2017/cite.bib
@@ -1,0 +1,19 @@
+@article{eglen_2017,
+ author = {Eglen, Stephen J and Marwick, Ben and Halchenko, Yaroslav
+O and Hanke, Michael and Sufi, Shoaib and Gleeson, Padraig
+and Silver, R Angus and Davison, Andrew P and Lanyon, Linda
+and Abrams, Mathew and Wachtler, Thomas and Willshaw, David
+J and Pouzat, Christophe and Poline, Jean-Baptiste},
+ doi = {10.1038/nn.4550},
+ issn = {1546-1726},
+ journal = {Nature Neuroscience},
+ month = {June},
+ number = {6},
+ pages = {770–773},
+ publisher = {Springer Science and Business Media LLC},
+ title = {Toward standard practices for sharing computer code and
+programs in neuroscience},
+ url = {http://dx.doi.org/10.1038/nn.4550},
+ volume = {20},
+ year = {2017}
+}

--- a/content/publications/eglen-2017/index.md
+++ b/content/publications/eglen-2017/index.md
@@ -1,0 +1,27 @@
+---
+title: Toward standard practices for sharing computer code and programs in neuroscience
+authors:
+- Stephen J Eglen
+- Ben Marwick
+- Yaroslav O Halchenko
+- Michael Hanke
+- Shoaib Sufi
+- Padraig Gleeson
+- R Angus Silver
+- Andrew P Davison
+- Linda Lanyon
+- Mathew Abrams
+- Thomas Wachtler
+- David J Willshaw
+- Christophe Pouzat
+- Jean-Baptiste Poline
+date: '2017-06-01'
+publishDate: '2024-12-19T23:16:36.427626Z'
+publication_types:
+- article-journal
+publication: '*Nature Neuroscience*'
+doi: 10.1038/nn.4550
+links:
+- name: URL
+  url: http://dx.doi.org/10.1038/nn.4550
+---

--- a/content/publications/eke-2022/cite.bib
+++ b/content/publications/eke-2022/cite.bib
@@ -1,0 +1,18 @@
+@article{eke_2022,
+ author = {Eke, Damian O. and Bernard, Amy and Bjaalie, Jan G. and
+Chavarriaga, Ricardo and Hanakawa, Takashi and Hannan,
+Anthony J. and Hill, Sean L. and Martone, Maryann E. and
+McMahon, Agnes and Ruebel, Oliver and Crook, Sharon and
+Thiels, Edda and Pestilli, Franco},
+ doi = {10.1016/j.neuron.2021.11.017},
+ issn = {0896-6273},
+ journal = {Neuron},
+ month = {February},
+ number = {4},
+ pages = {600–612},
+ publisher = {Elsevier BV},
+ title = {International data governance for neuroscience},
+ url = {http://dx.doi.org/10.1016/j.neuron.2021.11.017},
+ volume = {110},
+ year = {2022}
+}

--- a/content/publications/eke-2022/index.md
+++ b/content/publications/eke-2022/index.md
@@ -1,0 +1,26 @@
+---
+title: International data governance for neuroscience
+authors:
+- Damian O. Eke
+- Amy Bernard
+- Jan G. Bjaalie
+- Ricardo Chavarriaga
+- Takashi Hanakawa
+- Anthony J. Hannan
+- Sean L. Hill
+- Maryann E. Martone
+- Agnes McMahon
+- Oliver Ruebel
+- Sharon Crook
+- Edda Thiels
+- Franco Pestilli
+date: '2022-02-01'
+publishDate: '2024-12-19T23:16:36.432048Z'
+publication_types:
+- article-journal
+publication: '*Neuron*'
+doi: 10.1016/j.neuron.2021.11.017
+links:
+- name: URL
+  url: http://dx.doi.org/10.1016/j.neuron.2021.11.017
+---

--- a/content/publications/esteban-2020/cite.bib
+++ b/content/publications/esteban-2020/cite.bib
@@ -1,0 +1,25 @@
+@article{esteban_2020,
+ author = {Esteban, Oscar and Ciric, Rastko and Finc, Karolina and
+Blair, Ross W. and Markiewicz, Christopher J. and Moodie,
+Craig A. and Kent, James D. and Goncalves, Mathias and
+DuPre, Elizabeth and Gomez, Daniel E. P. and Ye, Zhifang
+and Salo, Taylor and Valabregue, Romain and Amlien, Inge K.
+and Liem, Franziskus and Jacoby, Nir and Stojić, Hrvoje
+and Cieslak, Matthew and Urchs, Sebastian and Halchenko,
+Yaroslav O. and Ghosh, Satrajit S. and De La Vega,
+Alejandro and Yarkoni, Tal and Wright, Jessey and Thompson,
+William H. and Poldrack, Russell A. and Gorgolewski,
+Krzysztof J.},
+ doi = {10.1038/s41596-020-0327-3},
+ issn = {1750-2799},
+ journal = {Nature Protocols},
+ month = {June},
+ number = {7},
+ pages = {2186–2202},
+ publisher = {Springer Science and Business Media LLC},
+ title = {Analysis of task-based functional MRI data preprocessed
+with fMRIPrep},
+ url = {http://dx.doi.org/10.1038/s41596-020-0327-3},
+ volume = {15},
+ year = {2020}
+}

--- a/content/publications/esteban-2020/index.md
+++ b/content/publications/esteban-2020/index.md
@@ -1,0 +1,40 @@
+---
+title: Analysis of task-based functional MRI data preprocessed with fMRIPrep
+authors:
+- Oscar Esteban
+- Rastko Ciric
+- Karolina Finc
+- Ross W. Blair
+- Christopher J. Markiewicz
+- Craig A. Moodie
+- James D. Kent
+- Mathias Goncalves
+- Elizabeth DuPre
+- Daniel E. P. Gomez
+- Zhifang Ye
+- Taylor Salo
+- Romain Valabregue
+- Inge K. Amlien
+- Franziskus Liem
+- Nir Jacoby
+- Hrvoje Stojić
+- Matthew Cieslak
+- Sebastian Urchs
+- Yaroslav O. Halchenko
+- Satrajit S. Ghosh
+- Alejandro De La Vega
+- Tal Yarkoni
+- Jessey Wright
+- William H. Thompson
+- Russell A. Poldrack
+- Krzysztof J. Gorgolewski
+date: '2020-06-01'
+publishDate: '2024-12-19T23:16:36.436338Z'
+publication_types:
+- article-journal
+publication: '*Nature Protocols*'
+doi: 10.1038/s41596-020-0327-3
+links:
+- name: URL
+  url: http://dx.doi.org/10.1038/s41596-020-0327-3
+---

--- a/content/publications/fenner-2019/cite.bib
+++ b/content/publications/fenner-2019/cite.bib
@@ -1,0 +1,16 @@
+@article{fenner_2019,
+ author = {Fenner, Martin and Crosas, Mercè and Grethe, Jeffrey S.
+and Kennedy, David and Hermjakob, Henning and Rocca-Serra,
+Phillippe and Durand, Gustavo and Berjon, Robin and
+Karcher, Sebastian and Martone, Maryann and Clark, Tim},
+ doi = {10.1038/s41597-019-0031-8},
+ issn = {2052-4463},
+ journal = {Scientific Data},
+ month = {April},
+ number = {1},
+ publisher = {Springer Science and Business Media LLC},
+ title = {A data citation roadmap for scholarly data repositories},
+ url = {http://dx.doi.org/10.1038/s41597-019-0031-8},
+ volume = {6},
+ year = {2019}
+}

--- a/content/publications/fenner-2019/index.md
+++ b/content/publications/fenner-2019/index.md
@@ -1,0 +1,24 @@
+---
+title: A data citation roadmap for scholarly data repositories
+authors:
+- Martin Fenner
+- Mercè Crosas
+- Jeffrey S. Grethe
+- David Kennedy
+- Henning Hermjakob
+- Phillippe Rocca-Serra
+- Gustavo Durand
+- Robin Berjon
+- Sebastian Karcher
+- Maryann Martone
+- Tim Clark
+date: '2019-04-01'
+publishDate: '2024-12-19T23:16:36.441113Z'
+publication_types:
+- article-journal
+publication: '*Scientific Data*'
+doi: 10.1038/s41597-019-0031-8
+links:
+- name: URL
+  url: http://dx.doi.org/10.1038/s41597-019-0031-8
+---

--- a/content/publications/ferris-2023/cite.bib
+++ b/content/publications/ferris-2023/cite.bib
@@ -1,0 +1,15 @@
+@article{ferris_2023,
+ author = {Ferris, Jennifer K. and Lo, Bethany P. and Khlif, Mohamed
+Salah and Brodtmann, Amy and Boyd, Lara A. and Liew,
+Sook-Lei},
+ doi = {10.3389/fnimg.2023.1099301},
+ issn = {2813-1193},
+ journal = {Frontiers in Neuroimaging},
+ month = {March},
+ publisher = {Frontiers Media SA},
+ title = {Optimizing automated white matter hyperintensity
+segmentation in individuals with stroke},
+ url = {http://dx.doi.org/10.3389/fnimg.2023.1099301},
+ volume = {2},
+ year = {2023}
+}

--- a/content/publications/ferris-2023/index.md
+++ b/content/publications/ferris-2023/index.md
@@ -1,0 +1,20 @@
+---
+title: Optimizing automated white matter hyperintensity segmentation in individuals
+  with stroke
+authors:
+- Jennifer K. Ferris
+- Bethany P. Lo
+- Mohamed Salah Khlif
+- Amy Brodtmann
+- Lara A. Boyd
+- Sook-Lei Liew
+date: '2023-03-01'
+publishDate: '2024-12-19T23:16:36.445225Z'
+publication_types:
+- article-journal
+publication: '*Frontiers in Neuroimaging*'
+doi: 10.3389/fnimg.2023.1099301
+links:
+- name: URL
+  url: http://dx.doi.org/10.3389/fnimg.2023.1099301
+---

--- a/content/publications/fitzpatrick-2019/cite.bib
+++ b/content/publications/fitzpatrick-2019/cite.bib
@@ -1,0 +1,14 @@
+@article{fitzpatrick_2019,
+ author = {Fitzpatrick, Paula and Mitchell, Teresa and Schmidt, R.C.
+and Kennedy, David and Frazier, Jean A.},
+ doi = {10.1016/j.neulet.2019.01.037},
+ issn = {0304-3940},
+ journal = {Neuroscience Letters},
+ month = {April},
+ pages = {24–30},
+ publisher = {Elsevier BV},
+ title = {Alpha band signatures of social synchrony},
+ url = {http://dx.doi.org/10.1016/j.neulet.2019.01.037},
+ volume = {699},
+ year = {2019}
+}

--- a/content/publications/fitzpatrick-2019/index.md
+++ b/content/publications/fitzpatrick-2019/index.md
@@ -1,0 +1,18 @@
+---
+title: Alpha band signatures of social synchrony
+authors:
+- Paula Fitzpatrick
+- Teresa Mitchell
+- R.C. Schmidt
+- David Kennedy
+- Jean A. Frazier
+date: '2019-04-01'
+publishDate: '2024-12-19T23:16:36.449205Z'
+publication_types:
+- article-journal
+publication: '*Neuroscience Letters*'
+doi: 10.1016/j.neulet.2019.01.037
+links:
+- name: URL
+  url: http://dx.doi.org/10.1016/j.neulet.2019.01.037
+---

--- a/content/publications/gan-or-2020/cite.bib
+++ b/content/publications/gan-or-2020/cite.bib
@@ -1,0 +1,25 @@
+@article{gan_or_2020,
+ author = {Gan-Or, Ziv and Rao, Trisha and Leveille, Etienne and
+Degroot, Clotilde and Chouinard, Sylvain and Cicchetti,
+Francesca and Dagher, Alain and Das, Samir and Desautels,
+Alex and Drouin-Ouellet, Janelle and Durcan, Thomas and
+Gagnon, Jean-François and Genge, Angela and Karamchandani,
+Jason and Lafontaine, Anne-Louise and Sun, Sonia Lai Wing
+and Langlois, Mélanie and Levesque, Martin and Melmed,
+Calvin and Panisset, Michel and Parent, Martin and Poline,
+Jean-Baptiste and Postuma, Ronald B. and Pourcher,
+Emmanuelle and Rouleau, Guy A. and Sharp, Madeleine and
+Monchi, Oury and Dupré, Nicolas and Fon, Edward A.},
+ doi = {10.3233/jpd-191775},
+ issn = {1877-718X},
+ journal = {Journal of Parkinson’s Disease},
+ month = {January},
+ number = {1},
+ pages = {301–313},
+ publisher = {SAGE Publications},
+ title = {The Quebec Parkinson Network: A Researcher-Patient
+Matching Platform and Multimodal Biorepository},
+ url = {http://dx.doi.org/10.3233/jpd-191775},
+ volume = {10},
+ year = {2020}
+}

--- a/content/publications/gan-or-2020/index.md
+++ b/content/publications/gan-or-2020/index.md
@@ -1,0 +1,43 @@
+---
+title: 'The Quebec Parkinson Network: A Researcher-Patient Matching Platform and Multimodal
+  Biorepository'
+authors:
+- Ziv Gan-Or
+- Trisha Rao
+- Etienne Leveille
+- Clotilde Degroot
+- Sylvain Chouinard
+- Francesca Cicchetti
+- Alain Dagher
+- Samir Das
+- Alex Desautels
+- Janelle Drouin-Ouellet
+- Thomas Durcan
+- Jean-François Gagnon
+- Angela Genge
+- Jason Karamchandani
+- Anne-Louise Lafontaine
+- Sonia Lai Wing Sun
+- Mélanie Langlois
+- Martin Levesque
+- Calvin Melmed
+- Michel Panisset
+- Martin Parent
+- Jean-Baptiste Poline
+- Ronald B. Postuma
+- Emmanuelle Pourcher
+- Guy A. Rouleau
+- Madeleine Sharp
+- Oury Monchi
+- Nicolas Dupré
+- Edward A. Fon
+date: '2020-01-01'
+publishDate: '2024-12-19T23:16:36.453155Z'
+publication_types:
+- article-journal
+publication: '*Journal of Parkinson’s Disease*'
+doi: 10.3233/jpd-191775
+links:
+- name: URL
+  url: http://dx.doi.org/10.3233/jpd-191775
+---

--- a/content/publications/gau-2021/cite.bib
+++ b/content/publications/gau-2021/cite.bib
@@ -1,0 +1,98 @@
+@article{gau_2021,
+ author = {Gau, Rémi and Noble, Stephanie and Heuer, Katja and
+Bottenhorn, Katherine L. and Bilgin, Isil P. and Yang,
+Yu-Fang and Huntenburg, Julia M. and Bayer, Johanna M.M.
+and Bethlehem, Richard A.I. and Rhoads, Shawn A. and
+Vogelbacher, Christoph and Borghesani, Valentina and
+Levitis, Elizabeth and Wang, Hao-Ting and Van Den Bossche,
+Sofie and Kobeleva, Xenia and Legarreta, Jon Haitz and
+Guay, Samuel and Atay, Selim Melvin and Varoquaux, Gael P.
+and Huijser, Dorien C. and Sandström, Malin S. and
+Herholz, Peer and Nastase, Samuel A. and Badhwar, AmanPreet
+and Dumas, Guillaume and Schwab, Simon and Moia, Stefano
+and Dayan, Michael and Bassil, Yasmine and Brooks, Paula P.
+and Mancini, Matteo and Shine, James M. and O’Connor,
+David and Xie, Xihe and Poggiali, Davide and Friedrich,
+Patrick and Heinsfeld, Anibal S. and Riedl, Lydia and Toro,
+Roberto and Caballero-Gaudes, César and Eklund, Anders and
+Garner, Kelly G. and Nolan, Christopher R. and Demeter,
+Damion V. and Barrios, Fernando A. and Merchant, Junaid S.
+and McDevitt, Elizabeth A. and Oostenveld, Robert and
+Craddock, R. Cameron and Rokem, Ariel and Doyle, Andrew and
+Ghosh, Satrajit S. and Nikolaidis, Aki and Stanley, Olivia
+W. and Uruñuela, Eneko and Anousheh, Nasim and
+Arnatkeviciute, Aurina and Auzias, Guillaume and Bachar,
+Dipankar and Bannier, Elise and Basanisi, Ruggero and
+Basavaraj, Arshitha and Bedini, Marco and Bellec, Pierre
+and Benn, R. Austin and Berluti, Kathryn and Bollmann,
+Steffen and Bollmann, Saskia and Bradley, Claire and Brown,
+Jesse and Buchweitz, Augusto and Callahan, Patrick and
+Chan, Micaela Y. and Chandio, Bramsh Q. and Cheng, Theresa
+and Chopra, Sidhant and Chung, Ai Wern and Close, Thomas G.
+and Combrisson, Etienne and Cona, Giorgia and Constable, R.
+Todd and Cury, Claire and Dadi, Kamalaker and Damasceno,
+Pablo F. and Das, Samir and De Vico Fallani, Fabrizio and
+DeStasio, Krista and Dickie, Erin W. and Dorfschmidt, Lena
+and Duff, Eugene P. and DuPre, Elizabeth and Dziura, Sarah
+and Esper, Nathalia B. and Esteban, Oscar and Fadnavis,
+Shreyas and Flandin, Guillaume and Flannery, Jessica E. and
+Flournoy, John and Forkel, Stephanie J. and Franco,
+Alexandre R. and Ganesan, Saampras and Gao, Siyuan and
+García Alanis, José C. and Garyfallidis, Eleftherios and
+Glatard, Tristan and Glerean, Enrico and Gonzalez-Castillo,
+Javier and Gould van Praag, Cassandra D. and Greene,
+Abigail S. and Gupta, Geetika and Hahn, Catherine Alice and
+Halchenko, Yaroslav O. and Handwerker, Daniel and Hartmann,
+Thomas S. and Hayot-Sasson, Valérie and Heunis, Stephan
+and Hoffstaedter, Felix and Hohmann, Daniela M. and Horien,
+Corey and Ioanas, Horea-Ioan and Iordan, Alexandru and
+Jiang, Chao and Joseph, Michael and Kai, Jason and
+Karakuzu, Agah and Kennedy, David N. and Keshavan, Anisha
+and Khan, Ali R. and Kiar, Gregory and Klink, P. Christiaan
+and Koppelmans, Vincent and Koudoro, Serge and Laird,
+Angela R. and Langs, Georg and Laws, Marissa and Licandro,
+Roxane and Liew, Sook-Lei and Lipic, Tomislav and Litinas,
+Krisanne and Lurie, Daniel J. and Lussier, Désirée and
+Madan, Christopher R. and Mais, Lea-Theresa and Mansour L,
+Sina and Manzano-Patron, J.P. and Maoutsa, Dimitra and
+Marcon, Matheus and Margulies, Daniel S. and Marinato,
+Giorgio and Marinazzo, Daniele and Markiewicz, Christopher
+J. and Maumet, Camille and Meneguzzi, Felipe and Meunier,
+David and Milham, Michael P. and Mills, Kathryn L. and
+Momi, Davide and Moreau, Clara A. and Motala, Aysha and
+Moxon-Emre, Iska and Nichols, Thomas E. and Nielson, Dylan
+M. and Nilsonne, Gustav and Novello, Lisa and O’Brien,
+Caroline and Olafson, Emily and Oliver, Lindsay D. and
+Onofrey, John A. and Orchard, Edwina R. and Oudyk, Kendra
+and Park, Patrick J. and Parsapoor, Mahboobeh and Pasquini,
+Lorenzo and Peltier, Scott and Pernet, Cyril R. and
+Pienaar, Rudolph and Pinheiro-Chagas, Pedro and Poline,
+Jean-Baptiste and Qiu, Anqi and Quendera, Tiago and Rice,
+Laura C. and Rocha-Hidalgo, Joscelin and Rutherford, Saige
+and Scharinger, Mathias and Scheinost, Dustin and Shariq,
+Deena and Shaw, Thomas B. and Siless, Viviana and
+Simmonite, Molly and Sirmpilatze, Nikoloz and Spence, Hayli
+and Sprenger, Julia and Stajduhar, Andrija and Szinte,
+Martin and Takerkart, Sylvain and Tam, Angela and
+Tejavibulya, Link and Thiebaut de Schotten, Michel and
+Thome, Ina and Tomaz da Silva, Laura and Traut, Nicolas and
+Uddin, Lucina Q. and Vallesi, Antonino and VanMeter, John
+W. and Vijayakumar, Nandita and di Oleggio Castello, Matteo
+Visconti and Vohryzek, Jakub and Vukojević, Jakša and
+Whitaker, Kirstie Jane and Whitmore, Lucy and Wideman,
+Steve and Witt, Suzanne T. and Xie, Hua and Xu, Ting and
+Yan, Chao-Gan and Yeh, Fang-Cheng and Yeo, B.T. Thomas and
+Zuo, Xi-Nian},
+ doi = {10.1016/j.neuron.2021.04.001},
+ issn = {0896-6273},
+ journal = {Neuron},
+ month = {June},
+ number = {11},
+ pages = {1769–1775},
+ publisher = {Elsevier BV},
+ title = {Brainhack: Developing a culture of open, inclusive,
+community-driven neuroscience},
+ url = {http://dx.doi.org/10.1016/j.neuron.2021.04.001},
+ volume = {109},
+ year = {2021}
+}

--- a/content/publications/gau-2021/index.md
+++ b/content/publications/gau-2021/index.md
@@ -1,0 +1,232 @@
+---
+title: 'Brainhack: Developing a culture of open, inclusive, community-driven neuroscience'
+authors:
+- Rémi Gau
+- Stephanie Noble
+- Katja Heuer
+- Katherine L. Bottenhorn
+- Isil P. Bilgin
+- Yu-Fang Yang
+- Julia M. Huntenburg
+- Johanna M.M. Bayer
+- Richard A.I. Bethlehem
+- Shawn A. Rhoads
+- Christoph Vogelbacher
+- Valentina Borghesani
+- Elizabeth Levitis
+- Hao-Ting Wang
+- Sofie Van Den Bossche
+- Xenia Kobeleva
+- Jon Haitz Legarreta
+- Samuel Guay
+- Selim Melvin Atay
+- Gael P. Varoquaux
+- Dorien C. Huijser
+- Malin S. Sandström
+- Peer Herholz
+- Samuel A. Nastase
+- AmanPreet Badhwar
+- Guillaume Dumas
+- Simon Schwab
+- Stefano Moia
+- Michael Dayan
+- Yasmine Bassil
+- Paula P. Brooks
+- Matteo Mancini
+- James M. Shine
+- David O’Connor
+- Xihe Xie
+- Davide Poggiali
+- Patrick Friedrich
+- Anibal S. Heinsfeld
+- Lydia Riedl
+- Roberto Toro
+- César Caballero-Gaudes
+- Anders Eklund
+- Kelly G. Garner
+- Christopher R. Nolan
+- Damion V. Demeter
+- Fernando A. Barrios
+- Junaid S. Merchant
+- Elizabeth A. McDevitt
+- Robert Oostenveld
+- R. Cameron Craddock
+- Ariel Rokem
+- Andrew Doyle
+- Satrajit S. Ghosh
+- Aki Nikolaidis
+- Olivia W. Stanley
+- Eneko Uruñuela
+- Nasim Anousheh
+- Aurina Arnatkeviciute
+- Guillaume Auzias
+- Dipankar Bachar
+- Elise Bannier
+- Ruggero Basanisi
+- Arshitha Basavaraj
+- Marco Bedini
+- Pierre Bellec
+- R. Austin Benn
+- Kathryn Berluti
+- Steffen Bollmann
+- Saskia Bollmann
+- Claire Bradley
+- Jesse Brown
+- Augusto Buchweitz
+- Patrick Callahan
+- Micaela Y. Chan
+- Bramsh Q. Chandio
+- Theresa Cheng
+- Sidhant Chopra
+- Ai Wern Chung
+- Thomas G. Close
+- Etienne Combrisson
+- Giorgia Cona
+- R. Todd Constable
+- Claire Cury
+- Kamalaker Dadi
+- Pablo F. Damasceno
+- Samir Das
+- Fabrizio De Vico Fallani
+- Krista DeStasio
+- Erin W. Dickie
+- Lena Dorfschmidt
+- Eugene P. Duff
+- Elizabeth DuPre
+- Sarah Dziura
+- Nathalia B. Esper
+- Oscar Esteban
+- Shreyas Fadnavis
+- Guillaume Flandin
+- Jessica E. Flannery
+- John Flournoy
+- Stephanie J. Forkel
+- Alexandre R. Franco
+- Saampras Ganesan
+- Siyuan Gao
+- José C. García Alanis
+- Eleftherios Garyfallidis
+- Tristan Glatard
+- Enrico Glerean
+- Javier Gonzalez-Castillo
+- Cassandra D. Gould van Praag
+- Abigail S. Greene
+- Geetika Gupta
+- Catherine Alice Hahn
+- Yaroslav O. Halchenko
+- Daniel Handwerker
+- Thomas S. Hartmann
+- Valérie Hayot-Sasson
+- Stephan Heunis
+- Felix Hoffstaedter
+- Daniela M. Hohmann
+- Corey Horien
+- Horea-Ioan Ioanas
+- Alexandru Iordan
+- Chao Jiang
+- Michael Joseph
+- Jason Kai
+- Agah Karakuzu
+- David N. Kennedy
+- Anisha Keshavan
+- Ali R. Khan
+- Gregory Kiar
+- P. Christiaan Klink
+- Vincent Koppelmans
+- Serge Koudoro
+- Angela R. Laird
+- Georg Langs
+- Marissa Laws
+- Roxane Licandro
+- Sook-Lei Liew
+- Tomislav Lipic
+- Krisanne Litinas
+- Daniel J. Lurie
+- Désirée Lussier
+- Christopher R. Madan
+- Lea-Theresa Mais
+- Sina Mansour L
+- J.P. Manzano-Patron
+- Dimitra Maoutsa
+- Matheus Marcon
+- Daniel S. Margulies
+- Giorgio Marinato
+- Daniele Marinazzo
+- Christopher J. Markiewicz
+- Camille Maumet
+- Felipe Meneguzzi
+- David Meunier
+- Michael P. Milham
+- Kathryn L. Mills
+- Davide Momi
+- Clara A. Moreau
+- Aysha Motala
+- Iska Moxon-Emre
+- Thomas E. Nichols
+- Dylan M. Nielson
+- Gustav Nilsonne
+- Lisa Novello
+- Caroline O’Brien
+- Emily Olafson
+- Lindsay D. Oliver
+- John A. Onofrey
+- Edwina R. Orchard
+- Kendra Oudyk
+- Patrick J. Park
+- Mahboobeh Parsapoor
+- Lorenzo Pasquini
+- Scott Peltier
+- Cyril R. Pernet
+- Rudolph Pienaar
+- Pedro Pinheiro-Chagas
+- Jean-Baptiste Poline
+- Anqi Qiu
+- Tiago Quendera
+- Laura C. Rice
+- Joscelin Rocha-Hidalgo
+- Saige Rutherford
+- Mathias Scharinger
+- Dustin Scheinost
+- Deena Shariq
+- Thomas B. Shaw
+- Viviana Siless
+- Molly Simmonite
+- Nikoloz Sirmpilatze
+- Hayli Spence
+- Julia Sprenger
+- Andrija Stajduhar
+- Martin Szinte
+- Sylvain Takerkart
+- Angela Tam
+- Link Tejavibulya
+- Michel Thiebaut de Schotten
+- Ina Thome
+- Laura Tomaz da Silva
+- Nicolas Traut
+- Lucina Q. Uddin
+- Antonino Vallesi
+- John W. VanMeter
+- Nandita Vijayakumar
+- Matteo Visconti di Oleggio Castello
+- Jakub Vohryzek
+- Jakša Vukojević
+- Kirstie Jane Whitaker
+- Lucy Whitmore
+- Steve Wideman
+- Suzanne T. Witt
+- Hua Xie
+- Ting Xu
+- Chao-Gan Yan
+- Fang-Cheng Yeh
+- B.T. Thomas Yeo
+- Xi-Nian Zuo
+date: '2021-06-01'
+publishDate: '2024-12-19T23:16:36.457619Z'
+publication_types:
+- article-journal
+publication: '*Neuron*'
+doi: 10.1016/j.neuron.2021.04.001
+links:
+- name: URL
+  url: http://dx.doi.org/10.1016/j.neuron.2021.04.001
+---

--- a/content/publications/ghosh-2017/cite.bib
+++ b/content/publications/ghosh-2017/cite.bib
@@ -1,0 +1,15 @@
+@article{ghosh_2017,
+ author = {Ghosh, Satrajit S. and Poline, Jean-Baptiste and Keator,
+David B. and Halchenko, Yaroslav O. and Thomas, Adam G. and
+Kessler, Daniel A. and Kennedy, David N.},
+ doi = {10.12688/f1000research.10783.2},
+ issn = {2046-1402},
+ journal = {F1000Research},
+ month = {June},
+ pages = {124},
+ publisher = {F1000 Research Ltd},
+ title = {A very simple, re-executable neuroimaging publication},
+ url = {http://dx.doi.org/10.12688/f1000research.10783.2},
+ volume = {6},
+ year = {2017}
+}

--- a/content/publications/ghosh-2017/index.md
+++ b/content/publications/ghosh-2017/index.md
@@ -1,0 +1,20 @@
+---
+title: A very simple, re-executable neuroimaging publication
+authors:
+- Satrajit S. Ghosh
+- Jean-Baptiste Poline
+- David B. Keator
+- Yaroslav O. Halchenko
+- Adam G. Thomas
+- Daniel A. Kessler
+- David N. Kennedy
+date: '2017-06-01'
+publishDate: '2024-12-19T23:16:36.466026Z'
+publication_types:
+- article-journal
+publication: '*F1000Research*'
+doi: 10.12688/f1000research.10783.2
+links:
+- name: URL
+  url: http://dx.doi.org/10.12688/f1000research.10783.2
+---

--- a/content/publications/gorgolewski-2016/cite.bib
+++ b/content/publications/gorgolewski-2016/cite.bib
@@ -1,0 +1,24 @@
+@article{gorgolewski_2016,
+ author = {Gorgolewski, Krzysztof J. and Auer, Tibor and Calhoun,
+Vince D. and Craddock, R. Cameron and Das, Samir and Duff,
+Eugene P. and Flandin, Guillaume and Ghosh, Satrajit S. and
+Glatard, Tristan and Halchenko, Yaroslav O. and Handwerker,
+Daniel A. and Hanke, Michael and Keator, David and Li,
+Xiangrui and Michael, Zachary and Maumet, Camille and
+Nichols, B. Nolan and Nichols, Thomas E. and Pellman, John
+and Poline, Jean-Baptiste and Rokem, Ariel and Schaefer,
+Gunnar and Sochat, Vanessa and Triplett, William and
+Turner, Jessica A. and Varoquaux, Gaël and Poldrack,
+Russell A.},
+ doi = {10.1038/sdata.2016.44},
+ issn = {2052-4463},
+ journal = {Scientific Data},
+ month = {June},
+ number = {1},
+ publisher = {Springer Science and Business Media LLC},
+ title = {The brain imaging data structure, a format for organizing
+and describing outputs of neuroimaging experiments},
+ url = {http://dx.doi.org/10.1038/sdata.2016.44},
+ volume = {3},
+ year = {2016}
+}

--- a/content/publications/gorgolewski-2016/index.md
+++ b/content/publications/gorgolewski-2016/index.md
@@ -1,0 +1,41 @@
+---
+title: The brain imaging data structure, a format for organizing and describing outputs
+  of neuroimaging experiments
+authors:
+- Krzysztof J. Gorgolewski
+- Tibor Auer
+- Vince D. Calhoun
+- R. Cameron Craddock
+- Samir Das
+- Eugene P. Duff
+- Guillaume Flandin
+- Satrajit S. Ghosh
+- Tristan Glatard
+- Yaroslav O. Halchenko
+- Daniel A. Handwerker
+- Michael Hanke
+- David Keator
+- Xiangrui Li
+- Zachary Michael
+- Camille Maumet
+- B. Nolan Nichols
+- Thomas E. Nichols
+- John Pellman
+- Jean-Baptiste Poline
+- Ariel Rokem
+- Gunnar Schaefer
+- Vanessa Sochat
+- William Triplett
+- Jessica A. Turner
+- Gaël Varoquaux
+- Russell A. Poldrack
+date: '2016-06-01'
+publishDate: '2024-12-19T23:16:36.470138Z'
+publication_types:
+- article-journal
+publication: '*Scientific Data*'
+doi: 10.1038/sdata.2016.44
+links:
+- name: URL
+  url: http://dx.doi.org/10.1038/sdata.2016.44
+---

--- a/content/publications/gorgolewski-2017/cite.bib
+++ b/content/publications/gorgolewski-2017/cite.bib
@@ -1,0 +1,27 @@
+@article{gorgolewski_2017,
+ author = {Gorgolewski, Krzysztof J. and Alfaro-Almagro, Fidel and
+Auer, Tibor and Bellec, Pierre and Capotă, Mihai and
+Chakravarty, M. Mallar and Churchill, Nathan W. and Cohen,
+Alexander Li and Craddock, R. Cameron and Devenyi, Gabriel
+A. and Eklund, Anders and Esteban, Oscar and Flandin,
+Guillaume and Ghosh, Satrajit S. and Guntupalli, J. Swaroop
+and Jenkinson, Mark and Keshavan, Anisha and Kiar, Gregory
+and Liem, Franziskus and Raamana, Pradeep Reddy and
+Raffelt, David and Steele, Christopher J. and Quirion,
+Pierre-Olivier and Smith, Robert E. and Strother, Stephen
+C. and Varoquaux, Gaël and Wang, Yida and Yarkoni, Tal and
+Poldrack, Russell A.},
+ doi = {10.1371/journal.pcbi.1005209},
+ editor = {Schneidman, Dina},
+ issn = {1553-7358},
+ journal = {PLOS Computational Biology},
+ month = {March},
+ number = {3},
+ pages = {e1005209},
+ publisher = {Public Library of Science (PLoS)},
+ title = {BIDS apps: Improving ease of use, accessibility, and
+reproducibility of neuroimaging data analysis methods},
+ url = {http://dx.doi.org/10.1371/journal.pcbi.1005209},
+ volume = {13},
+ year = {2017}
+}

--- a/content/publications/gorgolewski-2017/index.md
+++ b/content/publications/gorgolewski-2017/index.md
@@ -1,0 +1,43 @@
+---
+title: 'BIDS apps: Improving ease of use, accessibility, and reproducibility of neuroimaging
+  data analysis methods'
+authors:
+- Krzysztof J. Gorgolewski
+- Fidel Alfaro-Almagro
+- Tibor Auer
+- Pierre Bellec
+- Mihai Capotă
+- M. Mallar Chakravarty
+- Nathan W. Churchill
+- Alexander Li Cohen
+- R. Cameron Craddock
+- Gabriel A. Devenyi
+- Anders Eklund
+- Oscar Esteban
+- Guillaume Flandin
+- Satrajit S. Ghosh
+- J. Swaroop Guntupalli
+- Mark Jenkinson
+- Anisha Keshavan
+- Gregory Kiar
+- Franziskus Liem
+- Pradeep Reddy Raamana
+- David Raffelt
+- Christopher J. Steele
+- Pierre-Olivier Quirion
+- Robert E. Smith
+- Stephen C. Strother
+- Gaël Varoquaux
+- Yida Wang
+- Tal Yarkoni
+- Russell A. Poldrack
+date: '2017-03-01'
+publishDate: '2024-12-19T23:16:36.474509Z'
+publication_types:
+- article-journal
+publication: '*PLOS Computational Biology*'
+doi: 10.1371/journal.pcbi.1005209
+links:
+- name: URL
+  url: http://dx.doi.org/10.1371/journal.pcbi.1005209
+---

--- a/content/publications/guell-2018/cite.bib
+++ b/content/publications/guell-2018/cite.bib
@@ -1,0 +1,13 @@
+@article{guell_2018,
+ author = {Guell, Xavier and Schmahmann, Jeremy D and Gabrieli, John
+DE and Ghosh, Satrajit S},
+ doi = {10.7554/elife.36652},
+ issn = {2050-084X},
+ journal = {eLife},
+ month = {August},
+ publisher = {eLife Sciences Publications, Ltd},
+ title = {Functional gradients of the cerebellum},
+ url = {http://dx.doi.org/10.7554/elife.36652},
+ volume = {7},
+ year = {2018}
+}

--- a/content/publications/guell-2018/index.md
+++ b/content/publications/guell-2018/index.md
@@ -1,0 +1,17 @@
+---
+title: Functional gradients of the cerebellum
+authors:
+- Xavier Guell
+- Jeremy D Schmahmann
+- John DE Gabrieli
+- Satrajit S Ghosh
+date: '2018-08-01'
+publishDate: '2024-12-19T23:16:36.479002Z'
+publication_types:
+- article-journal
+publication: '*eLife*'
+doi: 10.7554/elife.36652
+links:
+- name: URL
+  url: http://dx.doi.org/10.7554/elife.36652
+---

--- a/content/publications/guell-2019/cite.bib
+++ b/content/publications/guell-2019/cite.bib
@@ -1,0 +1,18 @@
+@article{guell_2019,
+ author = {Guell, Xavier and Goncalves, Mathias and Kaczmarzyk, Jakub
+R. and Gabrieli, John D. E. and Schmahmann, Jeremy D. and
+Ghosh, Satrajit S.},
+ doi = {10.1371/journal.pone.0210028},
+ editor = {Margulies, Daniel S.},
+ issn = {1932-6203},
+ journal = {PLOS ONE},
+ month = {January},
+ number = {1},
+ pages = {e0210028},
+ publisher = {Public Library of Science (PLoS)},
+ title = {LittleBrain: A gradient-based tool for the topographical
+interpretation of cerebellar neuroimaging findings},
+ url = {http://dx.doi.org/10.1371/journal.pone.0210028},
+ volume = {14},
+ year = {2019}
+}

--- a/content/publications/guell-2019/index.md
+++ b/content/publications/guell-2019/index.md
@@ -1,0 +1,20 @@
+---
+title: 'LittleBrain: A gradient-based tool for the topographical interpretation of
+  cerebellar neuroimaging findings'
+authors:
+- Xavier Guell
+- Mathias Goncalves
+- Jakub R. Kaczmarzyk
+- John D. E. Gabrieli
+- Jeremy D. Schmahmann
+- Satrajit S. Ghosh
+date: '2019-01-01'
+publishDate: '2024-12-19T23:16:36.482873Z'
+publication_types:
+- article-journal
+publication: '*PLOS ONE*'
+doi: 10.1371/journal.pone.0210028
+links:
+- name: URL
+  url: http://dx.doi.org/10.1371/journal.pone.0210028
+---

--- a/content/publications/hagler-2019/cite.bib
+++ b/content/publications/hagler-2019/cite.bib
@@ -1,0 +1,67 @@
+@article{hagler_2019,
+ author = {Hagler, Donald J. and Hatton, SeanN. and Cornejo, M.
+Daniela and Makowski, Carolina and Fair, Damien A. and
+Dick, Anthony Steven and Sutherland, Matthew T. and Casey,
+B.J. and Barch, Deanna M. and Harms, Michael P. and Watts,
+Richard and Bjork, James M. and Garavan, Hugh P. and
+Hilmer, Laura and Pung, Christopher J. and Sicat, Chelsea
+S. and Kuperman, Joshua and Bartsch, Hauke and Xue, Feng
+and Heitzeg, Mary M. and Laird, Angela R. and Trinh, Thanh
+T. and Gonzalez, Raul and Tapert, Susan F. and Riedel,
+Michael C. and Squeglia, Lindsay M. and Hyde, Luke W. and
+Rosenberg, Monica D. and Earl, Eric A. and Howlett, Katia
+D. and Baker, Fiona C. and Soules, Mary and Diaz, Jazmin
+and de Leon, Octavio Ruiz and Thompson, Wesley K. and
+Neale, Michael C. and Herting, Megan and Sowell, Elizabeth
+R. and Alvarez, Ruben P. and Hawes, Samuel W. and Sanchez,
+Mariana and Bodurka, Jerzy and Breslin, Florence J. and
+Morris, Amanda Sheffield and Paulus, Martin P. and Simmons,
+W. Kyle and Polimeni, Jonathan R. and van der Kouwe, Andre
+and Nencka, Andrew S. and Gray, Kevin M. and Pierpaoli,
+Carlo and Matochik, John A. and Noronha, Antonio and Aklin,
+Will M. and Conway, Kevin and Glantz, Meyer and Hoffman,
+Elizabeth and Little, Roger and Lopez, Marsha and
+Pariyadath, Vani and Weiss, Susan RB. and Wolff-Hughes,
+Dana L. and DelCarmen-Wiggins, Rebecca and Feldstein Ewing,
+Sarah W. and Miranda-Dominguez, Oscar and Nagel, Bonnie J.
+and Perrone, Anders J. and Sturgeon, Darrick T. and
+Goldstone, Aimee and Pfefferbaum, Adolf and Pohl, Kilian M.
+and Prouty, Devin and Uban, Kristina and Bookheimer, Susan
+Y. and Dapretto, Mirella and Galvan, Adriana and Bagot,
+Kara and Giedd, Jay and Infante, M. Alejandra and Jacobus,
+Joanna and Patrick, Kevin and Shilling, Paul D. and
+Desikan, Rahul and Li, Yi and Sugrue, Leo and Banich, Marie
+T. and Friedman, Naomi and Hewitt, John K. and Hopfer,
+Christian and Sakai, Joseph and Tanabe, Jody and Cottler,
+Linda B. and Nixon, Sara Jo and Chang, Linda and Cloak,
+Christine and Ernst, Thomas and Reeves, Gloria and Kennedy,
+David N. and Heeringa, Steve and Peltier, Scott and
+Schulenberg, John and Sripada, Chandra and Zucker, Robert
+A. and Iacono, William G. and Luciana, Monica and Calabro,
+Finnegan J. and Clark, Duncan B. and Lewis, David A. and
+Luna, Beatriz and Schirda, Claudiu and Brima, Tufikameni
+and Foxe, John J. and Freedman, Edward G. and Mruzek,
+Daniel W. and Mason, Michael J. and Huber, Rebekah and
+McGlade, Erin and Prescot, Andrew and Renshaw, Perry F. and
+Yurgelun-Todd, Deborah A. and Allgaier, Nicholas A. and
+Dumas, Julie A. and Ivanova, Masha and Potter, Alexandra
+and Florsheim, Paul and Larson, Christine and Lisdahl,
+Krista and Charness, Michael E. and Fuemmeler, Bernard and
+Hettema, John M. and Maes, Hermine H. and Steinberg, Joel
+and Anokhin, Andrey P. and Glaser, Paul and Heath, Andrew
+C. and Madden, Pamela A. and Baskin-Sommers, Arielle and
+Constable, R. Todd and Grant, Steven J. and Dowling,
+Gayathri J. and Brown, Sandra A. and Jernigan, Terry L. and
+Dale, Anders M.},
+ doi = {10.1016/j.neuroimage.2019.116091},
+ issn = {1053-8119},
+ journal = {NeuroImage},
+ month = {November},
+ pages = {116091},
+ publisher = {Elsevier BV},
+ title = {Image processing and analysis methods for the Adolescent
+Brain Cognitive Development Study},
+ url = {http://dx.doi.org/10.1016/j.neuroimage.2019.116091},
+ volume = {202},
+ year = {2019}
+}

--- a/content/publications/hagler-2019/index.md
+++ b/content/publications/hagler-2019/index.md
@@ -1,0 +1,157 @@
+---
+title: Image processing and analysis methods for the Adolescent Brain Cognitive Development
+  Study
+authors:
+- Donald J. Hagler
+- SeanN. Hatton
+- M. Daniela Cornejo
+- Carolina Makowski
+- Damien A. Fair
+- Anthony Steven Dick
+- Matthew T. Sutherland
+- B.J. Casey
+- Deanna M. Barch
+- Michael P. Harms
+- Richard Watts
+- James M. Bjork
+- Hugh P. Garavan
+- Laura Hilmer
+- Christopher J. Pung
+- Chelsea S. Sicat
+- Joshua Kuperman
+- Hauke Bartsch
+- Feng Xue
+- Mary M. Heitzeg
+- Angela R. Laird
+- Thanh T. Trinh
+- Raul Gonzalez
+- Susan F. Tapert
+- Michael C. Riedel
+- Lindsay M. Squeglia
+- Luke W. Hyde
+- Monica D. Rosenberg
+- Eric A. Earl
+- Katia D. Howlett
+- Fiona C. Baker
+- Mary Soules
+- Jazmin Diaz
+- Octavio Ruiz de Leon
+- Wesley K. Thompson
+- Michael C. Neale
+- Megan Herting
+- Elizabeth R. Sowell
+- Ruben P. Alvarez
+- Samuel W. Hawes
+- Mariana Sanchez
+- Jerzy Bodurka
+- Florence J. Breslin
+- Amanda Sheffield Morris
+- Martin P. Paulus
+- W. Kyle Simmons
+- Jonathan R. Polimeni
+- Andre van der Kouwe
+- Andrew S. Nencka
+- Kevin M. Gray
+- Carlo Pierpaoli
+- John A. Matochik
+- Antonio Noronha
+- Will M. Aklin
+- Kevin Conway
+- Meyer Glantz
+- Elizabeth Hoffman
+- Roger Little
+- Marsha Lopez
+- Vani Pariyadath
+- Susan RB. Weiss
+- Dana L. Wolff-Hughes
+- Rebecca DelCarmen-Wiggins
+- Sarah W. Feldstein Ewing
+- Oscar Miranda-Dominguez
+- Bonnie J. Nagel
+- Anders J. Perrone
+- Darrick T. Sturgeon
+- Aimee Goldstone
+- Adolf Pfefferbaum
+- Kilian M. Pohl
+- Devin Prouty
+- Kristina Uban
+- Susan Y. Bookheimer
+- Mirella Dapretto
+- Adriana Galvan
+- Kara Bagot
+- Jay Giedd
+- M. Alejandra Infante
+- Joanna Jacobus
+- Kevin Patrick
+- Paul D. Shilling
+- Rahul Desikan
+- Yi Li
+- Leo Sugrue
+- Marie T. Banich
+- Naomi Friedman
+- John K. Hewitt
+- Christian Hopfer
+- Joseph Sakai
+- Jody Tanabe
+- Linda B. Cottler
+- Sara Jo Nixon
+- Linda Chang
+- Christine Cloak
+- Thomas Ernst
+- Gloria Reeves
+- David N. Kennedy
+- Steve Heeringa
+- Scott Peltier
+- John Schulenberg
+- Chandra Sripada
+- Robert A. Zucker
+- William G. Iacono
+- Monica Luciana
+- Finnegan J. Calabro
+- Duncan B. Clark
+- David A. Lewis
+- Beatriz Luna
+- Claudiu Schirda
+- Tufikameni Brima
+- John J. Foxe
+- Edward G. Freedman
+- Daniel W. Mruzek
+- Michael J. Mason
+- Rebekah Huber
+- Erin McGlade
+- Andrew Prescot
+- Perry F. Renshaw
+- Deborah A. Yurgelun-Todd
+- Nicholas A. Allgaier
+- Julie A. Dumas
+- Masha Ivanova
+- Alexandra Potter
+- Paul Florsheim
+- Christine Larson
+- Krista Lisdahl
+- Michael E. Charness
+- Bernard Fuemmeler
+- John M. Hettema
+- Hermine H. Maes
+- Joel Steinberg
+- Andrey P. Anokhin
+- Paul Glaser
+- Andrew C. Heath
+- Pamela A. Madden
+- Arielle Baskin-Sommers
+- R. Todd Constable
+- Steven J. Grant
+- Gayathri J. Dowling
+- Sandra A. Brown
+- Terry L. Jernigan
+- Anders M. Dale
+date: '2019-11-01'
+publishDate: '2024-12-19T23:16:36.486880Z'
+publication_types:
+- article-journal
+publication: '*NeuroImage*'
+doi: 10.1016/j.neuroimage.2019.116091
+links:
+- name: URL
+  url: http://dx.doi.org/10.1016/j.neuroimage.2019.116091
+---

--- a/content/publications/halchenko-2021/cite.bib
+++ b/content/publications/halchenko-2021/cite.bib
@@ -1,0 +1,25 @@
+@article{halchenko_2021,
+ author = {Halchenko, Yaroslav and Meyer, Kyle and Poldrack, Benjamin
+and Solanky, Debanjum and Wagner, Adina and Gors, Jason and
+MacFarlane, Dave and Pustina, Dorian and Sochat, Vanessa
+and Ghosh, Satrajit and Mönch, Christian and Markiewicz,
+Christopher and Waite, Laura and Shlyakhter, Ilya and de la
+Vega, Alejandro and Hayashi, Soichi and Häusler, Christian
+and Poline, Jean-Baptiste and Kadelka, Tobias and Skytén,
+Kusti and Jarecka, Dorota and Kennedy, David and Strauss,
+Ted and Cieslak, Matt and Vavra, Peter and Ioanas,
+Horea-Ioan and Schneider, Robin and Pflüger, Mika and
+Haxby, James and Eickhoff, Simon and Hanke, Michael},
+ doi = {10.21105/joss.03262},
+ issn = {2475-9066},
+ journal = {Journal of Open Source Software},
+ month = {July},
+ number = {63},
+ pages = {3262},
+ publisher = {The Open Journal},
+ title = {DataLad: distributed system for joint management of code,
+data, and their relationship},
+ url = {http://dx.doi.org/10.21105/joss.03262},
+ volume = {6},
+ year = {2021}
+}

--- a/content/publications/halchenko-2021/index.md
+++ b/content/publications/halchenko-2021/index.md
@@ -1,0 +1,45 @@
+---
+title: 'DataLad: distributed system for joint management of code, data, and their
+  relationship'
+authors:
+- Yaroslav Halchenko
+- Kyle Meyer
+- Benjamin Poldrack
+- Debanjum Solanky
+- Adina Wagner
+- Jason Gors
+- Dave MacFarlane
+- Dorian Pustina
+- Vanessa Sochat
+- Satrajit Ghosh
+- Christian Mönch
+- Christopher Markiewicz
+- Laura Waite
+- Ilya Shlyakhter
+- Alejandro de la Vega
+- Soichi Hayashi
+- Christian Häusler
+- Jean-Baptiste Poline
+- Tobias Kadelka
+- Kusti Skytén
+- Dorota Jarecka
+- David Kennedy
+- Ted Strauss
+- Matt Cieslak
+- Peter Vavra
+- Horea-Ioan Ioanas
+- Robin Schneider
+- Mika Pflüger
+- James Haxby
+- Simon Eickhoff
+- Michael Hanke
+date: '2021-07-01'
+publishDate: '2024-12-19T23:16:36.493434Z'
+publication_types:
+- article-journal
+publication: '*Journal of Open Source Software*'
+doi: 10.21105/joss.03262
+links:
+- name: URL
+  url: http://dx.doi.org/10.21105/joss.03262
+---

--- a/content/publications/halchenko-2024/cite.bib
+++ b/content/publications/halchenko-2024/cite.bib
@@ -1,0 +1,25 @@
+@article{halchenko_2024,
+ author = {Halchenko, Yaroslav O. and Goncalves, Mathias and Ghosh,
+Satrajit and Velasco, Pablo and Visconti di Oleggio
+Castello, Matteo and Salo, Taylor and Wodder, John T. and
+Hanke, Michael and Sadil, Patrick and Gorgolewski,
+Krzysztof Jacek and Ioanas, Horea-Ioan and Rorden, Chris
+and Hendrickson, Timothy J. and Dayan, Michael and
+Houlihan, Sean Dae and Kent, James and Strauss, Ted and
+Lee, John and To, Isaac and Markiewicz, Christopher J. and
+Lukas, Darren and Butler, Ellyn R. and Thompson, Todd and
+Termenon, Maite and Smith, David V. and Macdonald, Austin
+and Kennedy, David N.},
+ doi = {10.21105/joss.05839},
+ issn = {2475-9066},
+ journal = {Journal of Open Source Software},
+ month = {July},
+ number = {99},
+ pages = {5839},
+ publisher = {The Open Journal},
+ title = {HeuDiConv — flexible DICOM conversion into structured
+directory layouts},
+ url = {http://dx.doi.org/10.21105/joss.05839},
+ volume = {9},
+ year = {2024}
+}

--- a/content/publications/halchenko-2024/index.md
+++ b/content/publications/halchenko-2024/index.md
@@ -1,0 +1,40 @@
+---
+title: HeuDiConv — flexible DICOM conversion into structured directory layouts
+authors:
+- Yaroslav O. Halchenko
+- Mathias Goncalves
+- Satrajit Ghosh
+- Pablo Velasco
+- Matteo Visconti di Oleggio Castello
+- Taylor Salo
+- John T. Wodder
+- Michael Hanke
+- Patrick Sadil
+- Krzysztof Jacek Gorgolewski
+- Horea-Ioan Ioanas
+- Chris Rorden
+- Timothy J. Hendrickson
+- Michael Dayan
+- Sean Dae Houlihan
+- James Kent
+- Ted Strauss
+- John Lee
+- Isaac To
+- Christopher J. Markiewicz
+- Darren Lukas
+- Ellyn R. Butler
+- Todd Thompson
+- Maite Termenon
+- David V. Smith
+- Austin Macdonald
+- David N. Kennedy
+date: '2024-07-01'
+publishDate: '2024-12-19T23:16:36.497843Z'
+publication_types:
+- article-journal
+publication: '*Journal of Open Source Software*'
+doi: 10.21105/joss.05839
+links:
+- name: URL
+  url: http://dx.doi.org/10.21105/joss.05839
+---

--- a/content/publications/hanke-2021/cite.bib
+++ b/content/publications/hanke-2021/cite.bib
@@ -1,0 +1,15 @@
+@article{hanke_2021,
+ author = {Hanke, Michael and Pestilli, Franco and Wagner, Adina S.
+and Markiewicz, Christopher J. and Poline, Jean-Baptiste
+and Halchenko, Yaroslav O.},
+ doi = {10.1515/nf-2020-0037},
+ issn = {0947-0875},
+ journal = {Neuroforum},
+ month = {January},
+ number = {0},
+ publisher = {Walter de Gruyter GmbH},
+ title = {In defense of decentralized research data management},
+ url = {http://dx.doi.org/10.1515/nf-2020-0037},
+ volume = {0},
+ year = {2021}
+}

--- a/content/publications/hanke-2021/index.md
+++ b/content/publications/hanke-2021/index.md
@@ -1,0 +1,19 @@
+---
+title: In defense of decentralized research data management
+authors:
+- Michael Hanke
+- Franco Pestilli
+- Adina S. Wagner
+- Christopher J. Markiewicz
+- Jean-Baptiste Poline
+- Yaroslav O. Halchenko
+date: '2021-01-01'
+publishDate: '2024-12-19T23:16:36.502232Z'
+publication_types:
+- article-journal
+publication: '*Neuroforum*'
+doi: 10.1515/nf-2020-0037
+links:
+- name: URL
+  url: http://dx.doi.org/10.1515/nf-2020-0037
+---

--- a/content/publications/hodge-2021/cite.bib
+++ b/content/publications/hodge-2021/cite.bib
@@ -1,0 +1,15 @@
+@article{hodge_2021,
+ author = {Hodge, Steven M. and Haselgrove, Christian and Honor, Leah
+and Kennedy, David N. and Frazier, Jean A.},
+ doi = {10.12688/f1000research.25306.2},
+ issn = {2046-1402},
+ journal = {F1000Research},
+ month = {March},
+ pages = {1031},
+ publisher = {F1000 Research Ltd},
+ title = {An assessment of the autism neuroimaging literature for
+the prospects of re-executability},
+ url = {http://dx.doi.org/10.12688/f1000research.25306.2},
+ volume = {9},
+ year = {2021}
+}

--- a/content/publications/hodge-2021/index.md
+++ b/content/publications/hodge-2021/index.md
@@ -1,0 +1,18 @@
+---
+title: An assessment of the autism neuroimaging literature for the prospects of re-executability
+authors:
+- Steven M. Hodge
+- Christian Haselgrove
+- Leah Honor
+- David N. Kennedy
+- Jean A. Frazier
+date: '2021-03-01'
+publishDate: '2024-12-19T23:16:36.506182Z'
+publication_types:
+- article-journal
+publication: '*F1000Research*'
+doi: 10.12688/f1000research.25306.2
+links:
+- name: URL
+  url: http://dx.doi.org/10.12688/f1000research.25306.2
+---

--- a/content/publications/honor-2016/cite.bib
+++ b/content/publications/honor-2016/cite.bib
@@ -1,0 +1,14 @@
+@article{honor_2016,
+ author = {Honor, Leah B. and Haselgrove, Christian and Frazier, Jean
+A. and Kennedy, David N.},
+ doi = {10.3389/fninf.2016.00034},
+ issn = {1662-5196},
+ journal = {Frontiers in Neuroinformatics},
+ month = {August},
+ publisher = {Frontiers Media SA},
+ title = {Data Citation in Neuroimaging: Proposed Best Practices for
+Data Identification and Attribution},
+ url = {http://dx.doi.org/10.3389/fninf.2016.00034},
+ volume = {10},
+ year = {2016}
+}

--- a/content/publications/honor-2016/index.md
+++ b/content/publications/honor-2016/index.md
@@ -1,0 +1,18 @@
+---
+title: 'Data Citation in Neuroimaging: Proposed Best Practices for Data Identification
+  and Attribution'
+authors:
+- Leah B. Honor
+- Christian Haselgrove
+- Jean A. Frazier
+- David N. Kennedy
+date: '2016-08-01'
+publishDate: '2024-12-19T23:16:36.510083Z'
+publication_types:
+- article-journal
+publication: '*Frontiers in Neuroinformatics*'
+doi: 10.3389/fninf.2016.00034
+links:
+- name: URL
+  url: http://dx.doi.org/10.3389/fninf.2016.00034
+---

--- a/content/publications/hubbard-2020/cite.bib
+++ b/content/publications/hubbard-2020/cite.bib
@@ -1,0 +1,20 @@
+@article{hubbard_2020,
+ author = {Hubbard, N.A. and Siless, V. and Frosch, I.R. and
+Goncalves, M. and Lo, N. and Wang, J. and Bauer, C.C.C. and
+Conroy, K. and Cosby, E. and Hay, A. and Jones, R. and
+Pinaire, M. and Vaz De Souza, F. and Vergara, G. and Ghosh,
+S. and Henin, A. and Hirshfeld-Becker, D.R. and Hofmann,
+S.G. and Rosso, I.M. and Auerbach, R.P. and Pizzagalli,
+D.A. and Yendiki, A. and Gabrieli, J.D.E. and
+Whitfield-Gabrieli, S.},
+ doi = {10.1016/j.nicl.2020.102240},
+ issn = {2213-1582},
+ journal = {NeuroImage: Clinical},
+ pages = {102240},
+ publisher = {Elsevier BV},
+ title = {Brain function and clinical characterization in the Boston
+adolescent neuroimaging of depression and anxiety study},
+ url = {http://dx.doi.org/10.1016/j.nicl.2020.102240},
+ volume = {27},
+ year = {2020}
+}

--- a/content/publications/hubbard-2020/index.md
+++ b/content/publications/hubbard-2020/index.md
@@ -1,0 +1,38 @@
+---
+title: Brain function and clinical characterization in the Boston adolescent neuroimaging
+  of depression and anxiety study
+authors:
+- N.A. Hubbard
+- V. Siless
+- I.R. Frosch
+- M. Goncalves
+- N. Lo
+- J. Wang
+- C.C.C. Bauer
+- K. Conroy
+- E. Cosby
+- A. Hay
+- R. Jones
+- M. Pinaire
+- F. Vaz De Souza
+- G. Vergara
+- S. Ghosh
+- A. Henin
+- D.R. Hirshfeld-Becker
+- S.G. Hofmann
+- I.M. Rosso
+- R.P. Auerbach
+- D.A. Pizzagalli
+- A. Yendiki
+- J.D.E. Gabrieli
+- S. Whitfield-Gabrieli
+date: '2020-01-01'
+publishDate: '2024-12-19T23:16:36.513979Z'
+publication_types:
+- article-journal
+publication: '*NeuroImage: Clinical*'
+doi: 10.1016/j.nicl.2020.102240
+links:
+- name: URL
+  url: http://dx.doi.org/10.1016/j.nicl.2020.102240
+---

--- a/content/publications/hubbard-2024/cite.bib
+++ b/content/publications/hubbard-2024/cite.bib
@@ -1,0 +1,19 @@
+@article{hubbard_2024,
+ author = {Hubbard, N. A. and Bauer, C. C. C. and Siless, V. and
+Auerbach, R. P. and Elam, J. S. and Frosch, I. R. and
+Henin, A. and Hofmann, S. G. and Hodge, M. R. and Jones, R.
+and Lenzini, P. and Lo, N. and Park, A. T. and Pizzagalli,
+D. A. and Vaz-DeSouza, F. and Gabrieli, J. D. E. and
+Whitfield-Gabrieli, S. and Yendiki, A. and Ghosh, S. S.},
+ doi = {10.1038/s41597-024-03629-x},
+ issn = {2052-4463},
+ journal = {Scientific Data},
+ month = {August},
+ number = {1},
+ publisher = {Springer Science and Business Media LLC},
+ title = {The Human Connectome Project of adolescent anxiety and
+depression dataset},
+ url = {http://dx.doi.org/10.1038/s41597-024-03629-x},
+ volume = {11},
+ year = {2024}
+}

--- a/content/publications/hubbard-2024/index.md
+++ b/content/publications/hubbard-2024/index.md
@@ -1,0 +1,32 @@
+---
+title: The Human Connectome Project of adolescent anxiety and depression dataset
+authors:
+- N. A. Hubbard
+- C. C. C. Bauer
+- V. Siless
+- R. P. Auerbach
+- J. S. Elam
+- I. R. Frosch
+- A. Henin
+- S. G. Hofmann
+- M. R. Hodge
+- R. Jones
+- P. Lenzini
+- N. Lo
+- A. T. Park
+- D. A. Pizzagalli
+- F. Vaz-DeSouza
+- J. D. E. Gabrieli
+- S. Whitfield-Gabrieli
+- A. Yendiki
+- S. S. Ghosh
+date: '2024-08-01'
+publishDate: '2024-12-19T23:16:36.518197Z'
+publication_types:
+- article-journal
+publication: '*Scientific Data*'
+doi: 10.1038/s41597-024-03629-x
+links:
+- name: URL
+  url: http://dx.doi.org/10.1038/s41597-024-03629-x
+---

--- a/content/publications/hung-2020/cite.bib
+++ b/content/publications/hung-2020/cite.bib
@@ -1,0 +1,19 @@
+@article{hung_2020,
+ author = {Hung, Yuwen and Uchida, Mai and Gaillard, Schuyler L. and
+Woodworth, Hilary and Kelberman, Caroline and Capella,
+James and Kadlec, Kelly and Goncalves, Mathias and Ghosh,
+Satrajit and Yendiki, Anastasia and Chai, Xiaoqian J. and
+Hirshfeld-Becker, Dina R. and Whitfield-Gabrieli, Susan and
+Gabrieli, John D.E. and Biederman, Joseph},
+ doi = {10.1016/j.nicl.2020.102266},
+ issn = {2213-1582},
+ journal = {NeuroImage: Clinical},
+ pages = {102266},
+ publisher = {Elsevier BV},
+ title = {Cingulum-Callosal white-matter microstructure associated
+with emotional dysregulation in children: A diffusion
+tensor imaging study},
+ url = {http://dx.doi.org/10.1016/j.nicl.2020.102266},
+ volume = {27},
+ year = {2020}
+}

--- a/content/publications/hung-2020/index.md
+++ b/content/publications/hung-2020/index.md
@@ -1,0 +1,29 @@
+---
+title: 'Cingulum-Callosal white-matter microstructure associated with emotional dysregulation
+  in children: A diffusion tensor imaging study'
+authors:
+- Yuwen Hung
+- Mai Uchida
+- Schuyler L. Gaillard
+- Hilary Woodworth
+- Caroline Kelberman
+- James Capella
+- Kelly Kadlec
+- Mathias Goncalves
+- Satrajit Ghosh
+- Anastasia Yendiki
+- Xiaoqian J. Chai
+- Dina R. Hirshfeld-Becker
+- Susan Whitfield-Gabrieli
+- John D.E. Gabrieli
+- Joseph Biederman
+date: '2020-01-01'
+publishDate: '2024-12-19T23:16:36.522387Z'
+publication_types:
+- article-journal
+publication: '*NeuroImage: Clinical*'
+doi: 10.1016/j.nicl.2020.102266
+links:
+- name: URL
+  url: http://dx.doi.org/10.1016/j.nicl.2020.102266
+---

--- a/content/publications/huntenburg-2017/cite.bib
+++ b/content/publications/huntenburg-2017/cite.bib
@@ -1,0 +1,17 @@
+@article{huntenburg_2017,
+ author = {Huntenburg, Julia M. and Bazin, Pierre-Louis and Goulas,
+Alexandros and Tardif, Christine L. and Villringer, Arno
+and Margulies, Daniel S.},
+ doi = {10.1093/cercor/bhx030},
+ issn = {1460-2199},
+ journal = {Cerebral Cortex},
+ month = {February},
+ number = {2},
+ pages = {981–997},
+ publisher = {Oxford University Press (OUP)},
+ title = {A Systematic Relationship Between Functional Connectivity
+and Intracortical Myelin in the Human Cerebral Cortex},
+ url = {http://dx.doi.org/10.1093/cercor/bhx030},
+ volume = {27},
+ year = {2017}
+}

--- a/content/publications/huntenburg-2017/index.md
+++ b/content/publications/huntenburg-2017/index.md
@@ -1,0 +1,20 @@
+---
+title: A Systematic Relationship Between Functional Connectivity and Intracortical
+  Myelin in the Human Cerebral Cortex
+authors:
+- Julia M. Huntenburg
+- Pierre-Louis Bazin
+- Alexandros Goulas
+- Christine L. Tardif
+- Arno Villringer
+- Daniel S. Margulies
+date: '2017-02-01'
+publishDate: '2024-12-19T23:16:36.526513Z'
+publication_types:
+- article-journal
+publication: '*Cerebral Cortex*'
+doi: 10.1093/cercor/bhx030
+links:
+- name: URL
+  url: http://dx.doi.org/10.1093/cercor/bhx030
+---

--- a/content/publications/ioanas-2024/cite.bib
+++ b/content/publications/ioanas-2024/cite.bib
@@ -1,0 +1,14 @@
+@article{ioanas_2024,
+ author = {Ioanas, Horea-Ioan and Macdonald, Austin and Halchenko,
+Yaroslav O.},
+ doi = {10.3389/fninf.2024.1376022},
+ issn = {1662-5196},
+ journal = {Frontiers in Neuroinformatics},
+ month = {July},
+ publisher = {Frontiers Media SA},
+ title = {Neuroimaging article reexecution and reproduction
+assessment system},
+ url = {http://dx.doi.org/10.3389/fninf.2024.1376022},
+ volume = {18},
+ year = {2024}
+}

--- a/content/publications/ioanas-2024/index.md
+++ b/content/publications/ioanas-2024/index.md
@@ -1,0 +1,16 @@
+---
+title: Neuroimaging article reexecution and reproduction assessment system
+authors:
+- Horea-Ioan Ioanas
+- Austin Macdonald
+- Yaroslav O. Halchenko
+date: '2024-07-01'
+publishDate: '2024-12-19T23:16:36.530496Z'
+publication_types:
+- article-journal
+publication: '*Frontiers in Neuroinformatics*'
+doi: 10.3389/fninf.2024.1376022
+links:
+- name: URL
+  url: http://dx.doi.org/10.3389/fninf.2024.1376022
+---

--- a/content/publications/irimia-2017/cite.bib
+++ b/content/publications/irimia-2017/cite.bib
@@ -1,0 +1,16 @@
+@article{irimia_2017,
+ author = {Irimia, Andrei and Wei, Susan and Lu, Nanshu and Moore,
+Constance M. and Kennedy, David N.},
+ doi = {10.1007/s12021-017-9335-z},
+ issn = {1559-0089},
+ journal = {Neuroinformatics},
+ month = {July},
+ number = {3},
+ pages = {227–230},
+ publisher = {Springer Science and Business Media LLC},
+ title = {Mobile Monitoring of Traumatic Brain Injury in Older
+Adults: Challenges and Opportunities},
+ url = {http://dx.doi.org/10.1007/s12021-017-9335-z},
+ volume = {15},
+ year = {2017}
+}

--- a/content/publications/irimia-2017/index.md
+++ b/content/publications/irimia-2017/index.md
@@ -1,0 +1,19 @@
+---
+title: 'Mobile Monitoring of Traumatic Brain Injury in Older Adults: Challenges and
+  Opportunities'
+authors:
+- Andrei Irimia
+- Susan Wei
+- Nanshu Lu
+- Constance M. Moore
+- David N. Kennedy
+date: '2017-07-01'
+publishDate: '2024-12-19T23:16:36.534379Z'
+publication_types:
+- article-journal
+publication: '*Neuroinformatics*'
+doi: 10.1007/s12021-017-9335-z
+links:
+- name: URL
+  url: http://dx.doi.org/10.1007/s12021-017-9335-z
+---

--- a/content/publications/james-2016/cite.bib
+++ b/content/publications/james-2016/cite.bib
@@ -1,0 +1,17 @@
+@article{james_2016,
+ author = {James, Eric G. and Leveille, Suzanne G. and Hausdorff,
+Jeffrey M. and Travison, Thomas and Kennedy, David N. and
+Tucker, Katherine L. and Al Snih, Soham and Markides,
+Kyriakos S. and Bean, Jonathan F.},
+ doi = {10.1093/gerona/glw236},
+ issn = {1758-535X},
+ journal = {The Journals of Gerontology Series A: Biological Sciences
+and Medical Sciences},
+ month = {December},
+ pages = {glw236},
+ publisher = {Oxford University Press (OUP)},
+ title = {Rhythmic Interlimb Coordination Impairments and the Risk
+for Developing Mobility Limitations},
+ url = {http://dx.doi.org/10.1093/gerona/glw236},
+ year = {2016}
+}

--- a/content/publications/james-2016/index.md
+++ b/content/publications/james-2016/index.md
@@ -1,0 +1,24 @@
+---
+title: Rhythmic Interlimb Coordination Impairments and the Risk for Developing Mobility
+  Limitations
+authors:
+- Eric G. James
+- Suzanne G. Leveille
+- Jeffrey M. Hausdorff
+- Thomas Travison
+- David N. Kennedy
+- Katherine L. Tucker
+- Soham Al Snih
+- Kyriakos S. Markides
+- Jonathan F. Bean
+date: '2016-12-01'
+publishDate: '2024-12-19T23:16:36.538363Z'
+publication_types:
+- article-journal
+publication: '*The Journals of Gerontology Series A: Biological Sciences and Medical
+  Sciences*'
+doi: 10.1093/gerona/glw236
+links:
+- name: URL
+  url: http://dx.doi.org/10.1093/gerona/glw236
+---

--- a/content/publications/kennedy-2017/cite.bib
+++ b/content/publications/kennedy-2017/cite.bib
@@ -1,0 +1,14 @@
+@article{kennedy_2017,
+ author = {Kennedy, David N.},
+ doi = {10.1007/s12021-017-9331-3},
+ issn = {1559-0089},
+ journal = {Neuroinformatics},
+ month = {April},
+ number = {2},
+ pages = {113–114},
+ publisher = {Springer Science and Business Media LLC},
+ title = {The Information Sharing Statement Grows Some Teeth},
+ url = {http://dx.doi.org/10.1007/s12021-017-9331-3},
+ volume = {15},
+ year = {2017}
+}

--- a/content/publications/kennedy-2017/index.md
+++ b/content/publications/kennedy-2017/index.md
@@ -1,0 +1,14 @@
+---
+title: The Information Sharing Statement Grows Some Teeth
+authors:
+- David N. Kennedy
+date: '2017-04-01'
+publishDate: '2024-12-19T23:16:36.542340Z'
+publication_types:
+- article-journal
+publication: '*Neuroinformatics*'
+doi: 10.1007/s12021-017-9331-3
+links:
+- name: URL
+  url: http://dx.doi.org/10.1007/s12021-017-9331-3
+---

--- a/content/publications/kennedy-2018/cite.bib
+++ b/content/publications/kennedy-2018/cite.bib
@@ -1,0 +1,15 @@
+@article{kennedy_2018,
+ author = {Kennedy, David N.},
+ doi = {10.1007/s12021-018-9379-8},
+ issn = {1559-0089},
+ journal = {Neuroinformatics},
+ month = {April},
+ number = {2},
+ pages = {149–150},
+ publisher = {Springer Science and Business Media LLC},
+ title = {Neuroimaging Neuroinformatics: Sample Size and Other
+Evolutionary Topics},
+ url = {http://dx.doi.org/10.1007/s12021-018-9379-8},
+ volume = {16},
+ year = {2018}
+}

--- a/content/publications/kennedy-2018/index.md
+++ b/content/publications/kennedy-2018/index.md
@@ -1,0 +1,14 @@
+---
+title: 'Neuroimaging Neuroinformatics: Sample Size and Other Evolutionary Topics'
+authors:
+- David N. Kennedy
+date: '2018-04-01'
+publishDate: '2024-12-19T23:16:36.546103Z'
+publication_types:
+- article-journal
+publication: '*Neuroinformatics*'
+doi: 10.1007/s12021-018-9379-8
+links:
+- name: URL
+  url: http://dx.doi.org/10.1007/s12021-018-9379-8
+---

--- a/content/publications/kennedy-2019/cite.bib
+++ b/content/publications/kennedy-2019/cite.bib
@@ -1,0 +1,21 @@
+@article{kennedy_2019,
+ author = {Kennedy, David N. and Abraham, Sanu A. and Bates, Julianna
+F. and Crowley, Albert and Ghosh, Satrajit and Gillespie,
+Tom and Goncalves, Mathias and Grethe, Jeffrey S. and
+Halchenko, Yaroslav O. and Hanke, Michael and Haselgrove,
+Christian and Hodge, Steven M. and Jarecka, Dorota and
+Kaczmarzyk, Jakub and Keator, David B. and Meyer, Kyle and
+Martone, Maryann E. and Padhy, Smruti and Poline,
+Jean-Baptiste and Preuss, Nina and Sincomb, Troy and
+Travers, Matt},
+ doi = {10.3389/fninf.2019.00001},
+ issn = {1662-5196},
+ journal = {Frontiers in Neuroinformatics},
+ month = {February},
+ publisher = {Frontiers Media SA},
+ title = {Everything Matters: The ReproNim Perspective on
+Reproducible Neuroimaging},
+ url = {http://dx.doi.org/10.3389/fninf.2019.00001},
+ volume = {13},
+ year = {2019}
+}

--- a/content/publications/kennedy-2019/index.md
+++ b/content/publications/kennedy-2019/index.md
@@ -1,0 +1,35 @@
+---
+title: 'Everything Matters: The ReproNim Perspective on Reproducible Neuroimaging'
+authors:
+- David N. Kennedy
+- Sanu A. Abraham
+- Julianna F. Bates
+- Albert Crowley
+- Satrajit Ghosh
+- Tom Gillespie
+- Mathias Goncalves
+- Jeffrey S. Grethe
+- Yaroslav O. Halchenko
+- Michael Hanke
+- Christian Haselgrove
+- Steven M. Hodge
+- Dorota Jarecka
+- Jakub Kaczmarzyk
+- David B. Keator
+- Kyle Meyer
+- Maryann E. Martone
+- Smruti Padhy
+- Jean-Baptiste Poline
+- Nina Preuss
+- Troy Sincomb
+- Matt Travers
+date: '2019-02-01'
+publishDate: '2024-12-19T23:16:36.549868Z'
+publication_types:
+- article-journal
+publication: '*Frontiers in Neuroinformatics*'
+doi: 10.3389/fninf.2019.00001
+links:
+- name: URL
+  url: http://dx.doi.org/10.3389/fninf.2019.00001
+---

--- a/content/publications/keshavan-2019/cite.bib
+++ b/content/publications/keshavan-2019/cite.bib
@@ -1,0 +1,13 @@
+@article{keshavan_2019,
+ author = {Keshavan, Anisha and Poline, Jean-Baptiste},
+ doi = {10.3389/fninf.2019.00003},
+ issn = {1662-5196},
+ journal = {Frontiers in Neuroinformatics},
+ month = {March},
+ publisher = {Frontiers Media SA},
+ title = {From the Wet Lab to the Web Lab: A Paradigm Shift in Brain
+Imaging Research},
+ url = {http://dx.doi.org/10.3389/fninf.2019.00003},
+ volume = {13},
+ year = {2019}
+}

--- a/content/publications/keshavan-2019/index.md
+++ b/content/publications/keshavan-2019/index.md
@@ -1,0 +1,15 @@
+---
+title: 'From the Wet Lab to the Web Lab: A Paradigm Shift in Brain Imaging Research'
+authors:
+- Anisha Keshavan
+- Jean-Baptiste Poline
+date: '2019-03-01'
+publishDate: '2024-12-19T23:16:36.554460Z'
+publication_types:
+- article-journal
+publication: '*Frontiers in Neuroinformatics*'
+doi: 10.3389/fninf.2019.00003
+links:
+- name: URL
+  url: http://dx.doi.org/10.3389/fninf.2019.00003
+---

--- a/content/publications/kiar-2023/cite.bib
+++ b/content/publications/kiar-2023/cite.bib
@@ -1,0 +1,19 @@
+@article{kiar_2023,
+ author = {Kiar, Gregory and Clucas, Jon and Feczko, Eric and
+Goncalves, Mathias and Jarecka, Dorota and Markiewicz,
+Christopher J. and Halchenko, Yaroslav O. and Hermosillo,
+Robert and Li, Xinhui and Miranda-Dominguez, Oscar and
+Ghosh, Satrajit and Poldrack, Russell A. and Satterthwaite,
+Theodore D. and Milham, Michael P. and Fair, Damien},
+ doi = {10.1038/s41562-023-01647-0},
+ issn = {2397-3374},
+ journal = {Nature Human Behaviour},
+ month = {June},
+ number = {7},
+ pages = {1027–1028},
+ publisher = {Springer Science and Business Media LLC},
+ title = {Align with the NMIND consortium for better neuroimaging},
+ url = {http://dx.doi.org/10.1038/s41562-023-01647-0},
+ volume = {7},
+ year = {2023}
+}

--- a/content/publications/kiar-2023/index.md
+++ b/content/publications/kiar-2023/index.md
@@ -1,0 +1,28 @@
+---
+title: Align with the NMIND consortium for better neuroimaging
+authors:
+- Gregory Kiar
+- Jon Clucas
+- Eric Feczko
+- Mathias Goncalves
+- Dorota Jarecka
+- Christopher J. Markiewicz
+- Yaroslav O. Halchenko
+- Robert Hermosillo
+- Xinhui Li
+- Oscar Miranda-Dominguez
+- Satrajit Ghosh
+- Russell A. Poldrack
+- Theodore D. Satterthwaite
+- Michael P. Milham
+- Damien Fair
+date: '2023-06-01'
+publishDate: '2024-12-19T23:16:36.558307Z'
+publication_types:
+- article-journal
+publication: '*Nature Human Behaviour*'
+doi: 10.1038/s41562-023-01647-0
+links:
+- name: URL
+  url: http://dx.doi.org/10.1038/s41562-023-01647-0
+---

--- a/content/publications/kim-2018/cite.bib
+++ b/content/publications/kim-2018/cite.bib
@@ -1,0 +1,15 @@
+@article{kim_2018,
+ author = {Kim, Yang-Min and Poline, Jean-Baptiste and Dumas,
+Guillaume},
+ doi = {10.1093/gigascience/giy077},
+ issn = {2047-217X},
+ journal = {GigaScience},
+ month = {June},
+ number = {7},
+ publisher = {Oxford University Press (OUP)},
+ title = {Experimenting with reproducibility: a case study of
+robustness in bioinformatics},
+ url = {http://dx.doi.org/10.1093/gigascience/giy077},
+ volume = {7},
+ year = {2018}
+}

--- a/content/publications/kim-2018/index.md
+++ b/content/publications/kim-2018/index.md
@@ -1,0 +1,16 @@
+---
+title: 'Experimenting with reproducibility: a case study of robustness in bioinformatics'
+authors:
+- Yang-Min Kim
+- Jean-Baptiste Poline
+- Guillaume Dumas
+date: '2018-06-01'
+publishDate: '2024-12-19T23:16:36.562428Z'
+publication_types:
+- article-journal
+publication: '*GigaScience*'
+doi: 10.1093/gigascience/giy077
+links:
+- name: URL
+  url: http://dx.doi.org/10.1093/gigascience/giy077
+---

--- a/content/publications/klein-2017/cite.bib
+++ b/content/publications/klein-2017/cite.bib
@@ -1,0 +1,18 @@
+@article{klein_2017,
+ author = {Klein, Arno and Ghosh, Satrajit S. and Bao, Forrest S. and
+Giard, Joachim and Häme, Yrjö and Stavsky, Eliezer and
+Lee, Noah and Rossa, Brian and Reuter, Martin and Chaibub
+Neto, Elias and Keshavan, Anisha},
+ doi = {10.1371/journal.pcbi.1005350},
+ editor = {Schneidman, Dina},
+ issn = {1553-7358},
+ journal = {PLOS Computational Biology},
+ month = {February},
+ number = {2},
+ pages = {e1005350},
+ publisher = {Public Library of Science (PLoS)},
+ title = {Mindboggling morphometry of human brains},
+ url = {http://dx.doi.org/10.1371/journal.pcbi.1005350},
+ volume = {13},
+ year = {2017}
+}

--- a/content/publications/klein-2017/index.md
+++ b/content/publications/klein-2017/index.md
@@ -1,0 +1,24 @@
+---
+title: Mindboggling morphometry of human brains
+authors:
+- Arno Klein
+- Satrajit S. Ghosh
+- Forrest S. Bao
+- Joachim Giard
+- Yrjö Häme
+- Eliezer Stavsky
+- Noah Lee
+- Brian Rossa
+- Martin Reuter
+- Elias Chaibub Neto
+- Anisha Keshavan
+date: '2017-02-01'
+publishDate: '2024-12-19T23:16:36.566389Z'
+publication_types:
+- article-journal
+publication: '*PLOS Computational Biology*'
+doi: 10.1371/journal.pcbi.1005350
+links:
+- name: URL
+  url: http://dx.doi.org/10.1371/journal.pcbi.1005350
+---

--- a/content/publications/klein-2021/cite.bib
+++ b/content/publications/klein-2021/cite.bib
@@ -1,0 +1,23 @@
+@article{klein_2021,
+ author = {Klein, Arno and Clucas, Jon and Krishnakumar, Anirudh and
+Ghosh, Satrajit S and Van Auken, Wilhelm and Thonet,
+Benjamin and Sabram, Ihor and Acuna, Nino and Keshavan,
+Anisha and Rossiter, Henry and Xiao, Yao and Semenuta,
+Sergey and Badioli, Alessandra and Konishcheva, Kseniia and
+Abraham, Sanu Ann and Alexander, Lindsay M and Merikangas,
+Kathleen R and Swendsen, Joel and Lindner, Ariel B and
+Milham, Michael P},
+ doi = {10.2196/22369},
+ issn = {1438-8871},
+ journal = {Journal of Medical Internet Research},
+ month = {November},
+ number = {11},
+ pages = {e22369},
+ publisher = {JMIR Publications Inc.},
+ title = {Remote Digital Psychiatry for Mobile Mental Health
+Assessment and Therapy: MindLogger Platform Development
+Study},
+ url = {http://dx.doi.org/10.2196/22369},
+ volume = {23},
+ year = {2021}
+}

--- a/content/publications/klein-2021/index.md
+++ b/content/publications/klein-2021/index.md
@@ -1,0 +1,34 @@
+---
+title: 'Remote Digital Psychiatry for Mobile Mental Health Assessment and Therapy:
+  MindLogger Platform Development Study'
+authors:
+- Arno Klein
+- Jon Clucas
+- Anirudh Krishnakumar
+- Satrajit S Ghosh
+- Wilhelm Van Auken
+- Benjamin Thonet
+- Ihor Sabram
+- Nino Acuna
+- Anisha Keshavan
+- Henry Rossiter
+- Yao Xiao
+- Sergey Semenuta
+- Alessandra Badioli
+- Kseniia Konishcheva
+- Sanu Ann Abraham
+- Lindsay M Alexander
+- Kathleen R Merikangas
+- Joel Swendsen
+- Ariel B Lindner
+- Michael P Milham
+date: '2021-11-01'
+publishDate: '2024-12-19T23:16:36.570480Z'
+publication_types:
+- article-journal
+publication: '*Journal of Medical Internet Research*'
+doi: 10.2196/22369
+links:
+- name: URL
+  url: http://dx.doi.org/10.2196/22369
+---

--- a/content/publications/kumar-2022/cite.bib
+++ b/content/publications/kumar-2022/cite.bib
@@ -1,0 +1,17 @@
+@article{kumar_2022,
+ author = {Kumar, Ashmita and Crowley, Albert and Queder, Nazek and
+Poline, JB and Ghosh, Satrajit S. and Kennedy, David and
+Grethe, Jeffrey S. and Helmer, Karl G. and Keator, David
+B.},
+ doi = {10.12688/f1000research.108008.2},
+ issn = {2046-1402},
+ journal = {F1000Research},
+ month = {July},
+ pages = {228},
+ publisher = {F1000 Research Ltd},
+ title = {The Neuroimaging Data Model Linear Regression Tool
+(nidm_linreg): PyNIDM Project},
+ url = {http://dx.doi.org/10.12688/f1000research.108008.2},
+ volume = {11},
+ year = {2022}
+}

--- a/content/publications/kumar-2022/index.md
+++ b/content/publications/kumar-2022/index.md
@@ -1,0 +1,22 @@
+---
+title: 'The Neuroimaging Data Model Linear Regression Tool (nidm_linreg): PyNIDM Project'
+authors:
+- Ashmita Kumar
+- Albert Crowley
+- Nazek Queder
+- JB Poline
+- Satrajit S. Ghosh
+- David Kennedy
+- Jeffrey S. Grethe
+- Karl G. Helmer
+- David B. Keator
+date: '2022-07-01'
+publishDate: '2024-12-19T23:16:36.574733Z'
+publication_types:
+- article-journal
+publication: '*F1000Research*'
+doi: 10.12688/f1000research.108008.2
+links:
+- name: URL
+  url: http://dx.doi.org/10.12688/f1000research.108008.2
+---

--- a/content/publications/larivi-re-2023/cite.bib
+++ b/content/publications/larivi-re-2023/cite.bib
@@ -1,0 +1,18 @@
+@article{larivi_re_2023,
+ author = {Larivière, Sara and Bayrak, Şeyma and Vos de Wael,
+Reinder and Benkarim, Oualid and Herholz, Peer and
+Rodriguez-Cruces, Raul and Paquola, Casey and Hong,
+Seok-Jun and Misic, Bratislav and Evans, Alan C. and Valk,
+Sofie L. and Bernhardt, Boris C.},
+ doi = {10.1016/j.neuroimage.2022.119807},
+ issn = {1053-8119},
+ journal = {NeuroImage},
+ month = {February},
+ pages = {119807},
+ publisher = {Elsevier BV},
+ title = {BrainStat: A toolbox for brain-wide statistics and
+multimodal feature associations},
+ url = {http://dx.doi.org/10.1016/j.neuroimage.2022.119807},
+ volume = {266},
+ year = {2023}
+}

--- a/content/publications/larivi-re-2023/index.md
+++ b/content/publications/larivi-re-2023/index.md
@@ -1,0 +1,25 @@
+---
+title: 'BrainStat: A toolbox for brain-wide statistics and multimodal feature associations'
+authors:
+- Sara Larivière
+- Şeyma Bayrak
+- Reinder Vos de Wael
+- Oualid Benkarim
+- Peer Herholz
+- Raul Rodriguez-Cruces
+- Casey Paquola
+- Seok-Jun Hong
+- Bratislav Misic
+- Alan C. Evans
+- Sofie L. Valk
+- Boris C. Bernhardt
+date: '2023-02-01'
+publishDate: '2024-12-19T23:16:36.578774Z'
+publication_types:
+- article-journal
+publication: '*NeuroImage*'
+doi: 10.1016/j.neuroimage.2022.119807
+links:
+- name: URL
+  url: http://dx.doi.org/10.1016/j.neuroimage.2022.119807
+---

--- a/content/publications/lin-2020/cite.bib
+++ b/content/publications/lin-2020/cite.bib
@@ -1,0 +1,19 @@
+@article{lin_2020,
+ author = {Lin, Dawei and Crabtree, Jonathan and Dillo, Ingrid and
+Downs, Robert R. and Edmunds, Rorie and Giaretta, David and
+De Giusti, Marisa and L’Hours, Hervé and Hugo, Wim and
+Jenkyns, Reyna and Khodiyar, Varsha and Martone, Maryann E.
+and Mokrane, Mustapha and Navale, Vivek and Petters,
+Jonathan and Sierman, Barbara and Sokolova, Dina V. and
+Stockhause, Martina and Westbrook, John},
+ doi = {10.1038/s41597-020-0486-7},
+ issn = {2052-4463},
+ journal = {Scientific Data},
+ month = {May},
+ number = {1},
+ publisher = {Springer Science and Business Media LLC},
+ title = {The TRUST Principles for digital repositories},
+ url = {http://dx.doi.org/10.1038/s41597-020-0486-7},
+ volume = {7},
+ year = {2020}
+}

--- a/content/publications/lin-2020/index.md
+++ b/content/publications/lin-2020/index.md
@@ -1,0 +1,32 @@
+---
+title: The TRUST Principles for digital repositories
+authors:
+- Dawei Lin
+- Jonathan Crabtree
+- Ingrid Dillo
+- Robert R. Downs
+- Rorie Edmunds
+- David Giaretta
+- Marisa De Giusti
+- Hervé L’Hours
+- Wim Hugo
+- Reyna Jenkyns
+- Varsha Khodiyar
+- Maryann E. Martone
+- Mustapha Mokrane
+- Vivek Navale
+- Jonathan Petters
+- Barbara Sierman
+- Dina V. Sokolova
+- Martina Stockhause
+- John Westbrook
+date: '2020-05-01'
+publishDate: '2024-12-19T23:16:36.582791Z'
+publication_types:
+- article-journal
+publication: '*Scientific Data*'
+doi: 10.1038/s41597-020-0486-7
+links:
+- name: URL
+  url: http://dx.doi.org/10.1038/s41597-020-0486-7
+---

--- a/content/publications/lin-2024/cite.bib
+++ b/content/publications/lin-2024/cite.bib
@@ -1,0 +1,16 @@
+@article{lin_2024,
+ author = {Lin, David J. and Backus, Deborah and Chakraborty, Stuti
+and Liew, Sook-Lei and Valero-Cuevas, Francisco J. and
+Patten, Carolynn and Cotton, R James},
+ doi = {10.1186/s12984-024-01309-w},
+ issn = {1743-0003},
+ journal = {Journal of NeuroEngineering and Rehabilitation},
+ month = {February},
+ number = {1},
+ publisher = {Springer Science and Business Media LLC},
+ title = {Transforming modeling in neurorehabilitation: clinical
+insights for personalized rehabilitation},
+ url = {http://dx.doi.org/10.1186/s12984-024-01309-w},
+ volume = {21},
+ year = {2024}
+}

--- a/content/publications/lin-2024/index.md
+++ b/content/publications/lin-2024/index.md
@@ -1,0 +1,21 @@
+---
+title: 'Transforming modeling in neurorehabilitation: clinical insights for personalized
+  rehabilitation'
+authors:
+- David J. Lin
+- Deborah Backus
+- Stuti Chakraborty
+- Sook-Lei Liew
+- Francisco J. Valero-Cuevas
+- Carolynn Patten
+- R James Cotton
+date: '2024-02-01'
+publishDate: '2024-12-19T23:16:36.586976Z'
+publication_types:
+- article-journal
+publication: '*Journal of NeuroEngineering and Rehabilitation*'
+doi: 10.1186/s12984-024-01309-w
+links:
+- name: URL
+  url: http://dx.doi.org/10.1186/s12984-024-01309-w
+---

--- a/content/publications/lo-2023/cite.bib
+++ b/content/publications/lo-2023/cite.bib
@@ -1,0 +1,14 @@
+@article{lo_2023,
+ author = {Lo, Bethany P. and Donnelly, Miranda R. and Barisano,
+Giuseppe and Liew, Sook-Lei},
+ doi = {10.3389/fnimg.2022.1098604},
+ issn = {2813-1193},
+ journal = {Frontiers in Neuroimaging},
+ month = {January},
+ publisher = {Frontiers Media SA},
+ title = {A standardized protocol for manually segmenting stroke
+lesions on high-resolution T1-weighted MR images},
+ url = {http://dx.doi.org/10.3389/fnimg.2022.1098604},
+ volume = {1},
+ year = {2023}
+}

--- a/content/publications/lo-2023/index.md
+++ b/content/publications/lo-2023/index.md
@@ -1,0 +1,18 @@
+---
+title: A standardized protocol for manually segmenting stroke lesions on high-resolution
+  T1-weighted MR images
+authors:
+- Bethany P. Lo
+- Miranda R. Donnelly
+- Giuseppe Barisano
+- Sook-Lei Liew
+date: '2023-01-01'
+publishDate: '2024-12-19T23:16:36.591137Z'
+publication_types:
+- article-journal
+publication: '*Frontiers in Neuroimaging*'
+doi: 10.3389/fnimg.2022.1098604
+links:
+- name: URL
+  url: http://dx.doi.org/10.3389/fnimg.2022.1098604
+---

--- a/content/publications/low-2020/cite.bib
+++ b/content/publications/low-2020/cite.bib
@@ -1,0 +1,12 @@
+@article{low_2020,
+ author = {Low, Daniel M. and Rao, Vishwanatha and Randolph, Gregory
+and Song, Phillip C. and Ghosh, Satrajit S.},
+ doi = {10.1101/2020.11.23.20235945},
+ month = {November},
+ publisher = {Cold Spring Harbor Laboratory},
+ title = {Identifying bias in models that detect vocal fold
+paralysis from audio recordings using explainable machine
+learning and clinician ratings},
+ url = {http://dx.doi.org/10.1101/2020.11.23.20235945},
+ year = {2020}
+}

--- a/content/publications/low-2020/index.md
+++ b/content/publications/low-2020/index.md
@@ -1,0 +1,19 @@
+---
+title: Identifying bias in models that detect vocal fold paralysis from audio recordings
+  using explainable machine learning and clinician ratings
+authors:
+- Daniel M. Low
+- Vishwanatha Rao
+- Gregory Randolph
+- Phillip C. Song
+- Satrajit S. Ghosh
+date: '2020-11-01'
+publishDate: '2024-12-19T23:16:36.594994Z'
+publication_types:
+- article-journal
+publication: '*Cold Spring Harbor Laboratory*'
+doi: 10.1101/2020.11.23.20235945
+links:
+- name: URL
+  url: http://dx.doi.org/10.1101/2020.11.23.20235945
+---

--- a/content/publications/low-2024/cite.bib
+++ b/content/publications/low-2024/cite.bib
@@ -1,0 +1,18 @@
+@article{low_2024,
+ author = {Low, Daniel M. and Rao, Vishwanatha and Randolph, Gregory
+and Song, Phillip C. and Ghosh, Satrajit S.},
+ doi = {10.1371/journal.pdig.0000516},
+ editor = {Li-Jessen, Nicole Yee-Key},
+ issn = {2767-3170},
+ journal = {PLOS Digital Health},
+ month = {May},
+ number = {5},
+ pages = {e0000516},
+ publisher = {Public Library of Science (PLoS)},
+ title = {Identifying bias in models that detect vocal fold
+paralysis from audio recordings using explainable machine
+learning and clinician ratings},
+ url = {http://dx.doi.org/10.1371/journal.pdig.0000516},
+ volume = {3},
+ year = {2024}
+}

--- a/content/publications/low-2024/index.md
+++ b/content/publications/low-2024/index.md
@@ -1,0 +1,19 @@
+---
+title: Identifying bias in models that detect vocal fold paralysis from audio recordings
+  using explainable machine learning and clinician ratings
+authors:
+- Daniel M. Low
+- Vishwanatha Rao
+- Gregory Randolph
+- Phillip C. Song
+- Satrajit S. Ghosh
+date: '2024-05-01'
+publishDate: '2024-12-19T23:16:36.598985Z'
+publication_types:
+- article-journal
+publication: '*PLOS Digital Health*'
+doi: 10.1371/journal.pdig.0000516
+links:
+- name: URL
+  url: http://dx.doi.org/10.1371/journal.pdig.0000516
+---

--- a/content/publications/makris-2023/cite.bib
+++ b/content/publications/makris-2023/cite.bib
@@ -1,0 +1,20 @@
+@article{makris_2023,
+ author = {Makris, Nikos and Rushmore, Richard and Kaiser, Jonathan
+and Albaugh, Matthew and Kubicki, Marek and Rathi, Yogesh
+and Zhang, Fan and O’Donnell, Lauren J. and Yeterian,
+Edward and Caviness, Verne S. and Kennedy, David N.},
+ doi = {10.1159/000530358},
+ issn = {1421-9859},
+ journal = {Developmental Neuroscience},
+ number = {4},
+ pages = {161–180},
+ publisher = {S. Karger AG},
+ title = {A Proposed Human Structural Brain Connectivity Matrix in
+the Center for Morphometric Analysis Harvard-Oxford Atlas
+Framework: A Historical Perspective and Future Direction
+for Enhancing the Precision of Human Structural
+Connectivity with a Novel Neuroanatomical Typology},
+ url = {http://dx.doi.org/10.1159/000530358},
+ volume = {45},
+ year = {2023}
+}

--- a/content/publications/makris-2023/index.md
+++ b/content/publications/makris-2023/index.md
@@ -1,0 +1,27 @@
+---
+title: 'A Proposed Human Structural Brain Connectivity Matrix in the Center for Morphometric
+  Analysis Harvard-Oxford Atlas Framework: A Historical Perspective and Future Direction
+  for Enhancing the Precision of Human Structural Connectivity with a Novel Neuroanatomical
+  Typology'
+authors:
+- Nikos Makris
+- Richard Rushmore
+- Jonathan Kaiser
+- Matthew Albaugh
+- Marek Kubicki
+- Yogesh Rathi
+- Fan Zhang
+- Lauren J. O’Donnell
+- Edward Yeterian
+- Verne S. Caviness
+- David N. Kennedy
+date: '2023-01-01'
+publishDate: '2024-12-19T23:16:36.602999Z'
+publication_types:
+- article-journal
+publication: '*Developmental Neuroscience*'
+doi: 10.1159/000530358
+links:
+- name: URL
+  url: http://dx.doi.org/10.1159/000530358
+---

--- a/content/publications/manelis-2021/cite.bib
+++ b/content/publications/manelis-2021/cite.bib
@@ -1,0 +1,17 @@
+@article{manelis_2021,
+ author = {Manelis, Anna and Soehner, Adriane and Halchenko, Yaroslav
+O. and Satz, Skye and Ragozzino, Rachel and Lucero, Mora
+and Swartz, Holly A. and Phillips, Mary L. and Versace,
+Amelia},
+ doi = {10.1038/s41598-021-87069-2},
+ issn = {2045-2322},
+ journal = {Scientific Reports},
+ month = {April},
+ number = {1},
+ publisher = {Springer Science and Business Media LLC},
+ title = {White matter abnormalities in adults with bipolar disorder
+type-II and unipolar depression},
+ url = {http://dx.doi.org/10.1038/s41598-021-87069-2},
+ volume = {11},
+ year = {2021}
+}

--- a/content/publications/manelis-2021/index.md
+++ b/content/publications/manelis-2021/index.md
@@ -1,0 +1,23 @@
+---
+title: White matter abnormalities in adults with bipolar disorder type-II and unipolar
+  depression
+authors:
+- Anna Manelis
+- Adriane Soehner
+- Yaroslav O. Halchenko
+- Skye Satz
+- Rachel Ragozzino
+- Mora Lucero
+- Holly A. Swartz
+- Mary L. Phillips
+- Amelia Versace
+date: '2021-04-01'
+publishDate: '2024-12-19T23:16:36.607405Z'
+publication_types:
+- article-journal
+publication: '*Scientific Reports*'
+doi: 10.1038/s41598-021-87069-2
+links:
+- name: URL
+  url: http://dx.doi.org/10.1038/s41598-021-87069-2
+---

--- a/content/publications/manelis-2022/cite.bib
+++ b/content/publications/manelis-2022/cite.bib
@@ -1,0 +1,17 @@
+@article{manelis_2022,
+ author = {Manelis, Anna and Halchenko, Yaroslav O. and Bonar, Lisa
+and Stiffler, Richelle S. and Satz, Skye and Miceli, Rachel
+and Ladouceur, Cecile D. and Bebko, Genna and Iyengar,
+Satish and Swartz, Holly A. and Phillips, Mary L.},
+ doi = {10.1038/s41398-022-02211-6},
+ issn = {2158-3188},
+ journal = {Translational Psychiatry},
+ month = {October},
+ number = {1},
+ publisher = {Springer Science and Business Media LLC},
+ title = {Working memory updating in individuals with bipolar and
+unipolar depression: fMRI study},
+ url = {http://dx.doi.org/10.1038/s41398-022-02211-6},
+ volume = {12},
+ year = {2022}
+}

--- a/content/publications/manelis-2022/index.md
+++ b/content/publications/manelis-2022/index.md
@@ -1,0 +1,25 @@
+---
+title: 'Working memory updating in individuals with bipolar and unipolar depression:
+  fMRI study'
+authors:
+- Anna Manelis
+- Yaroslav O. Halchenko
+- Lisa Bonar
+- Richelle S. Stiffler
+- Skye Satz
+- Rachel Miceli
+- Cecile D. Ladouceur
+- Genna Bebko
+- Satish Iyengar
+- Holly A. Swartz
+- Mary L. Phillips
+date: '2022-10-01'
+publishDate: '2024-12-19T23:16:36.611558Z'
+publication_types:
+- article-journal
+publication: '*Translational Psychiatry*'
+doi: 10.1038/s41398-022-02211-6
+links:
+- name: URL
+  url: http://dx.doi.org/10.1038/s41398-022-02211-6
+---

--- a/content/publications/margulies-2016/cite.bib
+++ b/content/publications/margulies-2016/cite.bib
@@ -1,0 +1,19 @@
+@article{margulies_2016,
+ author = {Margulies, Daniel S. and Ghosh, Satrajit S. and Goulas,
+Alexandros and Falkiewicz, Marcel and Huntenburg, Julia M.
+and Langs, Georg and Bezgin, Gleb and Eickhoff, Simon B.
+and Castellanos, F. Xavier and Petrides, Michael and
+Jefferies, Elizabeth and Smallwood, Jonathan},
+ doi = {10.1073/pnas.1608282113},
+ issn = {1091-6490},
+ journal = {Proceedings of the National Academy of Sciences},
+ month = {October},
+ number = {44},
+ pages = {12574–12579},
+ publisher = {Proceedings of the National Academy of Sciences},
+ title = {Situating the default-mode network along a principal
+gradient of macroscale cortical organization},
+ url = {http://dx.doi.org/10.1073/pnas.1608282113},
+ volume = {113},
+ year = {2016}
+}

--- a/content/publications/margulies-2016/index.md
+++ b/content/publications/margulies-2016/index.md
@@ -1,0 +1,26 @@
+---
+title: Situating the default-mode network along a principal gradient of macroscale
+  cortical organization
+authors:
+- Daniel S. Margulies
+- Satrajit S. Ghosh
+- Alexandros Goulas
+- Marcel Falkiewicz
+- Julia M. Huntenburg
+- Georg Langs
+- Gleb Bezgin
+- Simon B. Eickhoff
+- F. Xavier Castellanos
+- Michael Petrides
+- Elizabeth Jefferies
+- Jonathan Smallwood
+date: '2016-10-01'
+publishDate: '2024-12-19T23:16:36.615664Z'
+publication_types:
+- article-journal
+publication: '*Proceedings of the National Academy of Sciences*'
+doi: 10.1073/pnas.1608282113
+links:
+- name: URL
+  url: http://dx.doi.org/10.1073/pnas.1608282113
+---

--- a/content/publications/markello-2021/cite.bib
+++ b/content/publications/markello-2021/cite.bib
@@ -1,0 +1,15 @@
+@article{markello_2021,
+ author = {Markello, Ross D and Arnatkeviciute, Aurina and Poline,
+Jean-Baptiste and Fulcher, Ben D and Fornito, Alex and
+Misic, Bratislav},
+ doi = {10.7554/elife.72129},
+ issn = {2050-084X},
+ journal = {eLife},
+ month = {November},
+ publisher = {eLife Sciences Publications, Ltd},
+ title = {Standardizing workflows in imaging transcriptomics with
+the abagen toolbox},
+ url = {http://dx.doi.org/10.7554/elife.72129},
+ volume = {10},
+ year = {2021}
+}

--- a/content/publications/markello-2021/index.md
+++ b/content/publications/markello-2021/index.md
@@ -1,0 +1,19 @@
+---
+title: Standardizing workflows in imaging transcriptomics with the abagen toolbox
+authors:
+- Ross D Markello
+- Aurina Arnatkeviciute
+- Jean-Baptiste Poline
+- Ben D Fulcher
+- Alex Fornito
+- Bratislav Misic
+date: '2021-11-01'
+publishDate: '2024-12-19T23:16:36.619789Z'
+publication_types:
+- article-journal
+publication: '*eLife*'
+doi: 10.7554/elife.72129
+links:
+- name: URL
+  url: http://dx.doi.org/10.7554/elife.72129
+---

--- a/content/publications/markiewicz-2021/cite.bib
+++ b/content/publications/markiewicz-2021/cite.bib
@@ -1,0 +1,16 @@
+@article{markiewicz_2021,
+ author = {Markiewicz, Christopher J and Gorgolewski, Krzysztof J and
+Feingold, Franklin and Blair, Ross and Halchenko, Yaroslav
+O and Miller, Eric and Hardcastle, Nell and Wexler, Joe and
+Esteban, Oscar and Goncavles, Mathias and Jwa, Anita and
+Poldrack, Russell},
+ doi = {10.7554/elife.71774},
+ issn = {2050-084X},
+ journal = {eLife},
+ month = {October},
+ publisher = {eLife Sciences Publications, Ltd},
+ title = {The OpenNeuro resource for sharing of neuroscience data},
+ url = {http://dx.doi.org/10.7554/elife.71774},
+ volume = {10},
+ year = {2021}
+}

--- a/content/publications/markiewicz-2021/index.md
+++ b/content/publications/markiewicz-2021/index.md
@@ -1,0 +1,25 @@
+---
+title: The OpenNeuro resource for sharing of neuroscience data
+authors:
+- Christopher J Markiewicz
+- Krzysztof J Gorgolewski
+- Franklin Feingold
+- Ross Blair
+- Yaroslav O Halchenko
+- Eric Miller
+- Nell Hardcastle
+- Joe Wexler
+- Oscar Esteban
+- Mathias Goncavles
+- Anita Jwa
+- Russell Poldrack
+date: '2021-10-01'
+publishDate: '2024-12-19T23:16:36.623769Z'
+publication_types:
+- article-journal
+publication: '*eLife*'
+doi: 10.7554/elife.71774
+links:
+- name: URL
+  url: http://dx.doi.org/10.7554/elife.71774
+---

--- a/content/publications/maumet-2016/cite.bib
+++ b/content/publications/maumet-2016/cite.bib
@@ -1,0 +1,20 @@
+@article{maumet_2016,
+ author = {Maumet, Camille and Auer, Tibor and Bowring, Alexander and
+Chen, Gang and Das, Samir and Flandin, Guillaume and Ghosh,
+Satrajit and Glatard, Tristan and Gorgolewski, Krzysztof J.
+and Helmer, Karl G. and Jenkinson, Mark and Keator, David
+B. and Nichols, B. Nolan and Poline, Jean-Baptiste and
+Reynolds, Richard and Sochat, Vanessa and Turner, Jessica
+and Nichols, Thomas E.},
+ doi = {10.1038/sdata.2016.102},
+ issn = {2052-4463},
+ journal = {Scientific Data},
+ month = {December},
+ number = {1},
+ publisher = {Springer Science and Business Media LLC},
+ title = {Sharing brain mapping statistical results with the
+neuroimaging data model},
+ url = {http://dx.doi.org/10.1038/sdata.2016.102},
+ volume = {3},
+ year = {2016}
+}

--- a/content/publications/maumet-2016/index.md
+++ b/content/publications/maumet-2016/index.md
@@ -1,0 +1,31 @@
+---
+title: Sharing brain mapping statistical results with the neuroimaging data model
+authors:
+- Camille Maumet
+- Tibor Auer
+- Alexander Bowring
+- Gang Chen
+- Samir Das
+- Guillaume Flandin
+- Satrajit Ghosh
+- Tristan Glatard
+- Krzysztof J. Gorgolewski
+- Karl G. Helmer
+- Mark Jenkinson
+- David B. Keator
+- B. Nolan Nichols
+- Jean-Baptiste Poline
+- Richard Reynolds
+- Vanessa Sochat
+- Jessica Turner
+- Thomas E. Nichols
+date: '2016-12-01'
+publishDate: '2024-12-19T23:16:36.628031Z'
+publication_types:
+- article-journal
+publication: '*Scientific Data*'
+doi: 10.1038/sdata.2016.102
+links:
+- name: URL
+  url: http://dx.doi.org/10.1038/sdata.2016.102
+---

--- a/content/publications/mcavoy-2021/cite.bib
+++ b/content/publications/mcavoy-2021/cite.bib
@@ -1,0 +1,18 @@
+@article{mcavoy_2021,
+ author = {McAvoy, Malia and Prieto, Paola Calvachi and Kaczmarzyk,
+Jakub R. and Fernández, Iván Sánchez and McNulty, Jack
+and Smith, Timothy and Yu, Kun-Hsing and Gormley, William
+B. and Arnaout, Omar},
+ doi = {10.1038/s41598-021-94733-0},
+ issn = {2045-2322},
+ journal = {Scientific Reports},
+ month = {July},
+ number = {1},
+ publisher = {Springer Science and Business Media LLC},
+ title = {Classification of glioblastoma versus primary central
+nervous system lymphoma using convolutional neural
+networks},
+ url = {http://dx.doi.org/10.1038/s41598-021-94733-0},
+ volume = {11},
+ year = {2021}
+}

--- a/content/publications/mcavoy-2021/index.md
+++ b/content/publications/mcavoy-2021/index.md
@@ -1,0 +1,23 @@
+---
+title: Classification of glioblastoma versus primary central nervous system lymphoma
+  using convolutional neural networks
+authors:
+- Malia McAvoy
+- Paola Calvachi Prieto
+- Jakub R. Kaczmarzyk
+- Iván Sánchez Fernández
+- Jack McNulty
+- Timothy Smith
+- Kun-Hsing Yu
+- William B. Gormley
+- Omar Arnaout
+date: '2021-07-01'
+publishDate: '2024-12-19T23:16:36.632269Z'
+publication_types:
+- article-journal
+publication: '*Scientific Reports*'
+doi: 10.1038/s41598-021-94733-0
+links:
+- name: URL
+  url: http://dx.doi.org/10.1038/s41598-021-94733-0
+---

--- a/content/publications/mcnaughton-2022/cite.bib
+++ b/content/publications/mcnaughton-2022/cite.bib
@@ -1,0 +1,65 @@
+@article{mcnaughton_2022,
+ author = {McNaughton, Ryan and Pieper, Chris and Sakai, Osamu and
+Rollins, Julie V. and Zhang, Xin and Kennedy, David N. and
+Frazier, Jean A. and Douglass, Laurie and Heeren, Timothy
+and Fry, Rebecca C. and O’Shea, T. Michael and Kuban,
+Karl K. and Jara, Hernán and Rollins, Julie V. and Shah,
+Bhavesh and Singh, Rachana and Vaidya, Ruben and Van
+Marter, Linda and Martin, Camilla and Ware, Janice and
+Rollins, Caitlin and Cole, Cynthia and Perrin, Ellen and
+Sakai, Christina and Bednarek, Frank and Frazier, Jean and
+Ehrenkranz, Richard and Benjamin, Jennifer and Montgomery,
+Angela and O’Shea, T. Michael and Washburn, Lisa and
+Gogcu, Semsa and Bose, Carl and Warner, Diane and O’Shea,
+T. Michael and Engelke, Steve and Higginson, Amanda and
+Higginson, Jason and Bear, Kelly and Poortenga, Mariel and
+Pastyrnak, Steve and Karna, Padu and Paneth, Nigel and
+Lenski, Madeleine and Schreiber, Michael and Hunter, Scott
+and Msall, Michael and Batton, Danny and Klarr, Judith and
+Lee, Young Ah and Obeid, Rawad and Christianson, Karen and
+Klein, Deborah and Wagner, Katie and Pimental, Maureen and
+Hallisey, Collen and Coster, Taryn and Dolins, Maddie and
+Mittleman, Maggie and Haile, Hannah and Rohde, Julia and
+Nylen, Ellen and Neger, Emily and Mattern, Kathryn and Ma,
+Catherine and Toner, Deanna and Vitaro, Elizabeth and
+Venuti, Lauren and Powers, Beth and Foley, Ann and Sacco,
+Taylor and Williams, Joanne and Romano, Elaine and Henry,
+Christine and Hiatt, Debbie and Peters, Nancy and Brown,
+Patricia and Ansusinha, Emily and Smith, Jazmyne and Yang,
+Nou and Bose, Gennie and Wereszczak, Janice and Bernhardt,
+Janice and Adams, Joan and Wilson, Donna and Darden-Saad,
+Nancy and Williams, Bree and Jones, Emily and Sutton, Dinah
+and Rathbun, Julie and Fagerman, Stephanie and Boshoven,
+William and Johnson, Jalen and James, Brandon and Miras,
+Karen and Solomon, Carolyn and Weiland, Deborah and Yoon,
+Grace and Ramoskaite, Rugile and Wiggins, Suzanne and
+Washington, Krissy and Martin, Ryan and Prendergast,
+Barbara and Lynch, Emma and Kring, Beth and Smith, Anne and
+McQuiston, Susan and Butler, Samantha and Wilson, Rachel
+and McGhee, Kirsten and Lee, Patricia and Asgarian, Aimee
+and Sadhwani, Anjali and Henson, Brandi and Keller, Cecelia
+and Walkowiak, Jenifer and Barron, Susan and Miller, Alice
+and Dessureau, Brian and Wood, Molly and Damon-Minow, Jill
+and Romano, Elaine and Mayes, Linda and Tsatsanis, Kathy
+and Chawarska, Katarzyna and Kim, Sophy and Dieterich,
+Susan and Bearrs, Karen and Waldrep, Ellen and Friedman,
+Jackie and Hounshell, Gail and Allred, Debbie and Helms,
+Rebecca and Whitley, Lynn and Stainback, Gary and Bostic,
+Lisa and Jacobson, Amanda and McKeeman, Joni and Meyer,
+Echo and Price, Joan and Lloyd, Megan and Plesha-Troyke,
+Susan and Scott, Megan and Solomon, Katherine M. and
+Brooklier, Kara and Vogt, Kelly},
+ doi = {10.1148/radiol.210385},
+ issn = {1527-1315},
+ journal = {Radiology},
+ month = {August},
+ number = {2},
+ pages = {419–428},
+ publisher = {Radiological Society of North America (RSNA)},
+ title = {Quantitative MRI Characterization of the Extremely Preterm
+Brain at Adolescence: Atypical versus Neurotypical
+Developmental Pathways},
+ url = {http://dx.doi.org/10.1148/radiol.210385},
+ volume = {304},
+ year = {2022}
+}

--- a/content/publications/mcnaughton-2022/index.md
+++ b/content/publications/mcnaughton-2022/index.md
@@ -1,0 +1,160 @@
+---
+title: 'Quantitative MRI Characterization of the Extremely Preterm Brain at Adolescence:
+  Atypical versus Neurotypical Developmental Pathways'
+authors:
+- Ryan McNaughton
+- Chris Pieper
+- Osamu Sakai
+- Julie V. Rollins
+- Xin Zhang
+- David N. Kennedy
+- Jean A. Frazier
+- Laurie Douglass
+- Timothy Heeren
+- Rebecca C. Fry
+- T. Michael O’Shea
+- Karl K. Kuban
+- Hernán Jara
+- Julie V. Rollins
+- Bhavesh Shah
+- Rachana Singh
+- Ruben Vaidya
+- Linda Van Marter
+- Camilla Martin
+- Janice Ware
+- Caitlin Rollins
+- Cynthia Cole
+- Ellen Perrin
+- Christina Sakai
+- Frank Bednarek
+- Jean Frazier
+- Richard Ehrenkranz
+- Jennifer Benjamin
+- Angela Montgomery
+- T. Michael O’Shea
+- Lisa Washburn
+- Semsa Gogcu
+- Carl Bose
+- Diane Warner
+- T. Michael O’Shea
+- Steve Engelke
+- Amanda Higginson
+- Jason Higginson
+- Kelly Bear
+- Mariel Poortenga
+- Steve Pastyrnak
+- Padu Karna
+- Nigel Paneth
+- Madeleine Lenski
+- Michael Schreiber
+- Scott Hunter
+- Michael Msall
+- Danny Batton
+- Judith Klarr
+- Young Ah Lee
+- Rawad Obeid
+- Karen Christianson
+- Deborah Klein
+- Katie Wagner
+- Maureen Pimental
+- Collen Hallisey
+- Taryn Coster
+- Maddie Dolins
+- Maggie Mittleman
+- Hannah Haile
+- Julia Rohde
+- Ellen Nylen
+- Emily Neger
+- Kathryn Mattern
+- Catherine Ma
+- Deanna Toner
+- Elizabeth Vitaro
+- Lauren Venuti
+- Beth Powers
+- Ann Foley
+- Taylor Sacco
+- Joanne Williams
+- Elaine Romano
+- Christine Henry
+- Debbie Hiatt
+- Nancy Peters
+- Patricia Brown
+- Emily Ansusinha
+- Jazmyne Smith
+- Nou Yang
+- Gennie Bose
+- Janice Wereszczak
+- Janice Bernhardt
+- Joan Adams
+- Donna Wilson
+- Nancy Darden-Saad
+- Bree Williams
+- Emily Jones
+- Dinah Sutton
+- Julie Rathbun
+- Stephanie Fagerman
+- William Boshoven
+- Jalen Johnson
+- Brandon James
+- Karen Miras
+- Carolyn Solomon
+- Deborah Weiland
+- Grace Yoon
+- Rugile Ramoskaite
+- Suzanne Wiggins
+- Krissy Washington
+- Ryan Martin
+- Barbara Prendergast
+- Emma Lynch
+- Beth Kring
+- Anne Smith
+- Susan McQuiston
+- Samantha Butler
+- Rachel Wilson
+- Kirsten McGhee
+- Patricia Lee
+- Aimee Asgarian
+- Anjali Sadhwani
+- Brandi Henson
+- Cecelia Keller
+- Jenifer Walkowiak
+- Susan Barron
+- Alice Miller
+- Brian Dessureau
+- Molly Wood
+- Jill Damon-Minow
+- Elaine Romano
+- Linda Mayes
+- Kathy Tsatsanis
+- Katarzyna Chawarska
+- Sophy Kim
+- Susan Dieterich
+- Karen Bearrs
+- Ellen Waldrep
+- Jackie Friedman
+- Gail Hounshell
+- Debbie Allred
+- Rebecca Helms
+- Lynn Whitley
+- Gary Stainback
+- Lisa Bostic
+- Amanda Jacobson
+- Joni McKeeman
+- Echo Meyer
+- Joan Price
+- Megan Lloyd
+- Susan Plesha-Troyke
+- Megan Scott
+- Katherine M. Solomon
+- Kara Brooklier
+- Kelly Vogt
+date: '2022-08-01'
+publishDate: '2024-12-19T23:16:36.636308Z'
+publication_types:
+- article-journal
+publication: '*Radiology*'
+doi: 10.1148/radiol.210385
+links:
+- name: URL
+  url: http://dx.doi.org/10.1148/radiol.210385
+---

--- a/content/publications/millman-2018/cite.bib
+++ b/content/publications/millman-2018/cite.bib
@@ -1,0 +1,13 @@
+@article{millman_2018,
+ author = {Millman, K. Jarrod and Brett, Matthew and Barnowski, Ross
+and Poline, Jean-Baptiste},
+ doi = {10.3389/fnins.2018.00727},
+ issn = {1662-453X},
+ journal = {Frontiers in Neuroscience},
+ month = {October},
+ publisher = {Frontiers Media SA},
+ title = {Teaching Computational Reproducibility for Neuroimaging},
+ url = {http://dx.doi.org/10.3389/fnins.2018.00727},
+ volume = {12},
+ year = {2018}
+}

--- a/content/publications/millman-2018/index.md
+++ b/content/publications/millman-2018/index.md
@@ -1,0 +1,17 @@
+---
+title: Teaching Computational Reproducibility for Neuroimaging
+authors:
+- K. Jarrod Millman
+- Matthew Brett
+- Ross Barnowski
+- Jean-Baptiste Poline
+date: '2018-10-01'
+publishDate: '2024-12-19T23:16:36.642797Z'
+publication_types:
+- article-journal
+publication: '*Frontiers in Neuroscience*'
+doi: 10.3389/fnins.2018.00727
+links:
+- name: URL
+  url: http://dx.doi.org/10.3389/fnins.2018.00727
+---

--- a/content/publications/modarres-2021/cite.bib
+++ b/content/publications/modarres-2021/cite.bib
@@ -1,0 +1,18 @@
+@article{modarres_2021,
+ author = {Modarres, Mo and Cochran, David and Kennedy, David N. and
+Schmidt, Richard and Fitzpatrick, Paula and Frazier, Jean
+A.},
+ doi = {10.1007/s12021-021-09517-8},
+ issn = {1559-0089},
+ journal = {Neuroinformatics},
+ month = {March},
+ number = {1},
+ pages = {53–62},
+ publisher = {Springer Science and Business Media LLC},
+ title = {Biomarkers Based on Comprehensive Hierarchical EEG
+Coherence Analysis: Example Application to Social
+Competence in Autism (Preliminary Results)},
+ url = {http://dx.doi.org/10.1007/s12021-021-09517-8},
+ volume = {20},
+ year = {2021}
+}

--- a/content/publications/modarres-2021/index.md
+++ b/content/publications/modarres-2021/index.md
@@ -1,0 +1,20 @@
+---
+title: 'Biomarkers Based on Comprehensive Hierarchical EEG Coherence Analysis: Example
+  Application to Social Competence in Autism (Preliminary Results)'
+authors:
+- Mo Modarres
+- David Cochran
+- David N. Kennedy
+- Richard Schmidt
+- Paula Fitzpatrick
+- Jean A. Frazier
+date: '2021-03-01'
+publishDate: '2024-12-19T23:16:36.646851Z'
+publication_types:
+- article-journal
+publication: '*Neuroinformatics*'
+doi: 10.1007/s12021-021-09517-8
+links:
+- name: URL
+  url: http://dx.doi.org/10.1007/s12021-021-09517-8
+---

--- a/content/publications/modarres-2023/cite.bib
+++ b/content/publications/modarres-2023/cite.bib
@@ -1,0 +1,15 @@
+@article{modarres_2023,
+ author = {Modarres, Mo and Cochran, David and Kennedy, David N. and
+Frazier, Jean A.},
+ doi = {10.3389/fnhum.2023.1237651},
+ issn = {1662-5161},
+ journal = {Frontiers in Human Neuroscience},
+ month = {November},
+ publisher = {Frontiers Media SA},
+ title = {Comparison of comprehensive quantitative EEG metrics
+between typically developing boys and girls in resting
+state eyes-open and eyes-closed conditions},
+ url = {http://dx.doi.org/10.3389/fnhum.2023.1237651},
+ volume = {17},
+ year = {2023}
+}

--- a/content/publications/modarres-2023/index.md
+++ b/content/publications/modarres-2023/index.md
@@ -1,0 +1,18 @@
+---
+title: Comparison of comprehensive quantitative EEG metrics between typically developing
+  boys and girls in resting state eyes-open and eyes-closed conditions
+authors:
+- Mo Modarres
+- David Cochran
+- David N. Kennedy
+- Jean A. Frazier
+date: '2023-11-01'
+publishDate: '2024-12-19T23:16:36.650846Z'
+publication_types:
+- article-journal
+publication: '*Frontiers in Human Neuroscience*'
+doi: 10.3389/fnhum.2023.1237651
+links:
+- name: URL
+  url: http://dx.doi.org/10.3389/fnhum.2023.1237651
+---

--- a/content/publications/nastase-2021/cite.bib
+++ b/content/publications/nastase-2021/cite.bib
@@ -1,0 +1,22 @@
+@article{nastase_2021,
+ author = {Nastase, Samuel A. and Liu, Yun-Fei and Hillman, Hanna and
+Zadbood, Asieh and Hasenfratz, Liat and Keshavarzian,
+Neggin and Chen, Janice and Honey, Christopher J. and
+Yeshurun, Yaara and Regev, Mor and Nguyen, Mai and Chang,
+Claire H. C. and Baldassano, Christopher and Lositsky, Olga
+and Simony, Erez and Chow, Michael A. and Leong, Yuan Chang
+and Brooks, Paula P. and Micciche, Emily and Choe, Gina and
+Goldstein, Ariel and Vanderwal, Tamara and Halchenko,
+Yaroslav O. and Norman, Kenneth A. and Hasson, Uri},
+ doi = {10.1038/s41597-021-01033-3},
+ issn = {2052-4463},
+ journal = {Scientific Data},
+ month = {September},
+ number = {1},
+ publisher = {Springer Science and Business Media LLC},
+ title = {The “Narratives” fMRI dataset for evaluating models of
+naturalistic language comprehension},
+ url = {http://dx.doi.org/10.1038/s41597-021-01033-3},
+ volume = {8},
+ year = {2021}
+}

--- a/content/publications/nastase-2021/index.md
+++ b/content/publications/nastase-2021/index.md
@@ -1,0 +1,39 @@
+---
+title: The “Narratives” fMRI dataset for evaluating models of naturalistic language
+  comprehension
+authors:
+- Samuel A. Nastase
+- Yun-Fei Liu
+- Hanna Hillman
+- Asieh Zadbood
+- Liat Hasenfratz
+- Neggin Keshavarzian
+- Janice Chen
+- Christopher J. Honey
+- Yaara Yeshurun
+- Mor Regev
+- Mai Nguyen
+- Claire H. C. Chang
+- Christopher Baldassano
+- Olga Lositsky
+- Erez Simony
+- Michael A. Chow
+- Yuan Chang Leong
+- Paula P. Brooks
+- Emily Micciche
+- Gina Choe
+- Ariel Goldstein
+- Tamara Vanderwal
+- Yaroslav O. Halchenko
+- Kenneth A. Norman
+- Uri Hasson
+date: '2021-09-01'
+publishDate: '2024-12-19T23:16:36.654785Z'
+publication_types:
+- article-journal
+publication: '*Scientific Data*'
+doi: 10.1038/s41597-021-01033-3
+links:
+- name: URL
+  url: http://dx.doi.org/10.1038/s41597-021-01033-3
+---

--- a/content/publications/nichols-2017/cite.bib
+++ b/content/publications/nichols-2017/cite.bib
@@ -1,0 +1,20 @@
+@article{nichols_2017,
+ author = {Nichols, Thomas E and Das, Samir and Eickhoff, Simon B and
+Evans, Alan C and Glatard, Tristan and Hanke, Michael and
+Kriegeskorte, Nikolaus and Milham, Michael P and Poldrack,
+Russell A and Poline, Jean-Baptiste and Proal, Erika and
+Thirion, Bertrand and Van Essen, David C and White, Tonya
+and Yeo, B T Thomas},
+ doi = {10.1038/nn.4500},
+ issn = {1546-1726},
+ journal = {Nature Neuroscience},
+ month = {March},
+ number = {3},
+ pages = {299–303},
+ publisher = {Springer Science and Business Media LLC},
+ title = {Best practices in data analysis and sharing in
+neuroimaging using MRI},
+ url = {http://dx.doi.org/10.1038/nn.4500},
+ volume = {20},
+ year = {2017}
+}

--- a/content/publications/nichols-2017/index.md
+++ b/content/publications/nichols-2017/index.md
@@ -1,0 +1,28 @@
+---
+title: Best practices in data analysis and sharing in neuroimaging using MRI
+authors:
+- Thomas E Nichols
+- Samir Das
+- Simon B Eickhoff
+- Alan C Evans
+- Tristan Glatard
+- Michael Hanke
+- Nikolaus Kriegeskorte
+- Michael P Milham
+- Russell A Poldrack
+- Jean-Baptiste Poline
+- Erika Proal
+- Bertrand Thirion
+- David C Van Essen
+- Tonya White
+- B T Thomas Yeo
+date: '2017-03-01'
+publishDate: '2024-12-19T23:16:36.659132Z'
+publication_types:
+- article-journal
+publication: '*Nature Neuroscience*'
+doi: 10.1038/nn.4500
+links:
+- name: URL
+  url: http://dx.doi.org/10.1038/nn.4500
+---

--- a/content/publications/niso-2022/cite.bib
+++ b/content/publications/niso-2022/cite.bib
@@ -1,0 +1,22 @@
+@article{niso_2022,
+ author = {Niso, Guiomar and Botvinik-Nezer, Rotem and Appelhoff,
+Stefan and De La Vega, Alejandro and Esteban, Oscar and
+Etzel, Joset A. and Finc, Karolina and Ganz, Melanie and
+Gau, Rémi and Halchenko, Yaroslav O. and Herholz, Peer and
+Karakuzu, Agah and Keator, David B. and Markiewicz,
+Christopher J. and Maumet, Camille and Pernet, Cyril R. and
+Pestilli, Franco and Queder, Nazek and Schmitt, Tina and
+Sójka, Weronika and Wagner, Adina S. and Whitaker, Kirstie
+J. and Rieger, Jochem W.},
+ doi = {10.1016/j.neuroimage.2022.119623},
+ issn = {1053-8119},
+ journal = {NeuroImage},
+ month = {November},
+ pages = {119623},
+ publisher = {Elsevier BV},
+ title = {Open and reproducible neuroimaging: From study inception
+to publication},
+ url = {http://dx.doi.org/10.1016/j.neuroimage.2022.119623},
+ volume = {263},
+ year = {2022}
+}

--- a/content/publications/niso-2022/index.md
+++ b/content/publications/niso-2022/index.md
@@ -1,0 +1,36 @@
+---
+title: 'Open and reproducible neuroimaging: From study inception to publication'
+authors:
+- Guiomar Niso
+- Rotem Botvinik-Nezer
+- Stefan Appelhoff
+- Alejandro De La Vega
+- Oscar Esteban
+- Joset A. Etzel
+- Karolina Finc
+- Melanie Ganz
+- Rémi Gau
+- Yaroslav O. Halchenko
+- Peer Herholz
+- Agah Karakuzu
+- David B. Keator
+- Christopher J. Markiewicz
+- Camille Maumet
+- Cyril R. Pernet
+- Franco Pestilli
+- Nazek Queder
+- Tina Schmitt
+- Weronika Sójka
+- Adina S. Wagner
+- Kirstie J. Whitaker
+- Jochem W. Rieger
+date: '2022-11-01'
+publishDate: '2024-12-19T23:16:36.663301Z'
+publication_types:
+- article-journal
+publication: '*NeuroImage*'
+doi: 10.1016/j.neuroimage.2022.119623
+links:
+- name: URL
+  url: http://dx.doi.org/10.1016/j.neuroimage.2022.119623
+---

--- a/content/publications/notter-2022/cite.bib
+++ b/content/publications/notter-2022/cite.bib
@@ -1,0 +1,17 @@
+@article{notter_2022,
+ author = {Notter, Michael P. and Herholz, Peer and Da Costa, Sandra
+and Gulban, Omer F. and Isik, Ayse Ilkay and Gaglianese,
+Anna and Murray, Micah M.},
+ doi = {10.1007/s10548-022-00935-8},
+ issn = {1573-6792},
+ journal = {Brain Topography},
+ month = {December},
+ number = {2},
+ pages = {172–191},
+ publisher = {Springer Science and Business Media LLC},
+ title = {fMRIflows: A Consortium of Fully Automatic Univariate and
+Multivariate fMRI Processing Pipelines},
+ url = {http://dx.doi.org/10.1007/s10548-022-00935-8},
+ volume = {36},
+ year = {2022}
+}

--- a/content/publications/notter-2022/index.md
+++ b/content/publications/notter-2022/index.md
@@ -1,0 +1,21 @@
+---
+title: 'fMRIflows: A Consortium of Fully Automatic Univariate and Multivariate fMRI
+  Processing Pipelines'
+authors:
+- Michael P. Notter
+- Peer Herholz
+- Sandra Da Costa
+- Omer F. Gulban
+- Ayse Ilkay Isik
+- Anna Gaglianese
+- Micah M. Murray
+date: '2022-12-01'
+publishDate: '2024-12-19T23:16:36.667849Z'
+publication_types:
+- article-journal
+publication: '*Brain Topography*'
+doi: 10.1007/s10548-022-00935-8
+links:
+- name: URL
+  url: http://dx.doi.org/10.1007/s10548-022-00935-8
+---

--- a/content/publications/ozyurt-2018/cite.bib
+++ b/content/publications/ozyurt-2018/cite.bib
@@ -1,0 +1,13 @@
+@article{ozyurt_2018,
+ author = {Ozyurt, Ibrahim Burak and Grethe, Jeffrey S},
+ doi = {10.1093/database/bay130},
+ issn = {1758-0463},
+ journal = {Database},
+ month = {January},
+ publisher = {Oxford University Press (OUP)},
+ title = {Foundry: a message-oriented, horizontally scalable ETL
+system for scientific data integration and enhancement},
+ url = {http://dx.doi.org/10.1093/database/bay130},
+ volume = {2018},
+ year = {2018}
+}

--- a/content/publications/ozyurt-2018/index.md
+++ b/content/publications/ozyurt-2018/index.md
@@ -1,0 +1,16 @@
+---
+title: 'Foundry: a message-oriented, horizontally scalable ETL system for scientific
+  data integration and enhancement'
+authors:
+- Ibrahim Burak Ozyurt
+- Jeffrey S Grethe
+date: '2018-01-01'
+publishDate: '2024-12-19T23:16:36.671905Z'
+publication_types:
+- article-journal
+publication: '*Database*'
+doi: 10.1093/database/bay130
+links:
+- name: URL
+  url: http://dx.doi.org/10.1093/database/bay130
+---

--- a/content/publications/peraza-2023/cite.bib
+++ b/content/publications/peraza-2023/cite.bib
@@ -1,0 +1,17 @@
+@article{peraza_2023,
+ author = {Peraza, Julio A. and Salo, Taylor and Riedel, Michael C.
+and Bottenhorn, Katherine L. and Poline, Jean-Baptiste and
+Dockès, Jérôme and Kent, James D. and Bartley, Jessica
+E. and Flannery, Jessica S. and Hill-Bowen, Lauren D. and
+Lobo, Rosario Pintos and Poudel, Ranjita and Ray, Kimberly
+L. and Robinson, Jennifer L. and Laird, Robert W. and
+Sutherland, Matthew T. and de la Vega, Alejandro and Laird,
+Angela R.},
+ doi = {10.1101/2023.08.01.551505},
+ month = {August},
+ publisher = {Cold Spring Harbor Laboratory},
+ title = {Methods for decoding cortical gradients of functional
+connectivity},
+ url = {http://dx.doi.org/10.1101/2023.08.01.551505},
+ year = {2023}
+}

--- a/content/publications/peraza-2023/index.md
+++ b/content/publications/peraza-2023/index.md
@@ -1,0 +1,31 @@
+---
+title: Methods for decoding cortical gradients of functional connectivity
+authors:
+- Julio A. Peraza
+- Taylor Salo
+- Michael C. Riedel
+- Katherine L. Bottenhorn
+- Jean-Baptiste Poline
+- Jérôme Dockès
+- James D. Kent
+- Jessica E. Bartley
+- Jessica S. Flannery
+- Lauren D. Hill-Bowen
+- Rosario Pintos Lobo
+- Ranjita Poudel
+- Kimberly L. Ray
+- Jennifer L. Robinson
+- Robert W. Laird
+- Matthew T. Sutherland
+- Alejandro de la Vega
+- Angela R. Laird
+date: '2023-08-01'
+publishDate: '2024-12-19T23:16:36.675826Z'
+publication_types:
+- article-journal
+publication: '*Cold Spring Harbor Laboratory*'
+doi: 10.1101/2023.08.01.551505
+links:
+- name: URL
+  url: http://dx.doi.org/10.1101/2023.08.01.551505
+---

--- a/content/publications/perez-lebel-2022/cite.bib
+++ b/content/publications/perez-lebel-2022/cite.bib
@@ -1,0 +1,14 @@
+@article{perez_lebel_2022,
+ author = {Perez-Lebel, Alexandre and Varoquaux, Gaël and
+Le Morvan, Marine and Josse, Julie and Poline,
+Jean-Baptiste},
+ doi = {10.1093/gigascience/giac013},
+ issn = {2047-217X},
+ journal = {GigaScience},
+ publisher = {Oxford University Press (OUP)},
+ title = {Benchmarking missing-values approaches for predictive
+models on health databases},
+ url = {http://dx.doi.org/10.1093/gigascience/giac013},
+ volume = {11},
+ year = {2022}
+}

--- a/content/publications/perez-lebel-2022/index.md
+++ b/content/publications/perez-lebel-2022/index.md
@@ -1,0 +1,18 @@
+---
+title: Benchmarking missing-values approaches for predictive models on health databases
+authors:
+- Alexandre Perez-Lebel
+- Gaël Varoquaux
+- Marine Le Morvan
+- Julie Josse
+- Jean-Baptiste Poline
+date: '2022-01-01'
+publishDate: '2024-12-19T23:16:36.680066Z'
+publication_types:
+- article-journal
+publication: '*GigaScience*'
+doi: 10.1093/gigascience/giac013
+links:
+- name: URL
+  url: http://dx.doi.org/10.1093/gigascience/giac013
+---

--- a/content/publications/poldrack-2017/cite.bib
+++ b/content/publications/poldrack-2017/cite.bib
@@ -1,0 +1,18 @@
+@article{poldrack_2017,
+ author = {Poldrack, Russell A. and Baker, Chris I. and Durnez, Joke
+and Gorgolewski, Krzysztof J. and Matthews, Paul M. and
+Munafò, Marcus R. and Nichols, Thomas E. and Poline,
+Jean-Baptiste and Vul, Edward and Yarkoni, Tal},
+ doi = {10.1038/nrn.2016.167},
+ issn = {1471-0048},
+ journal = {Nature Reviews Neuroscience},
+ month = {January},
+ number = {2},
+ pages = {115–126},
+ publisher = {Springer Science and Business Media LLC},
+ title = {Scanning the horizon: towards transparent and reproducible
+neuroimaging research},
+ url = {http://dx.doi.org/10.1038/nrn.2016.167},
+ volume = {18},
+ year = {2017}
+}

--- a/content/publications/poldrack-2017/index.md
+++ b/content/publications/poldrack-2017/index.md
@@ -1,0 +1,23 @@
+---
+title: 'Scanning the horizon: towards transparent and reproducible neuroimaging research'
+authors:
+- Russell A. Poldrack
+- Chris I. Baker
+- Joke Durnez
+- Krzysztof J. Gorgolewski
+- Paul M. Matthews
+- Marcus R. Munafò
+- Thomas E. Nichols
+- Jean-Baptiste Poline
+- Edward Vul
+- Tal Yarkoni
+date: '2017-01-01'
+publishDate: '2024-12-19T23:16:36.683992Z'
+publication_types:
+- article-journal
+publication: '*Nature Reviews Neuroscience*'
+doi: 10.1038/nrn.2016.167
+links:
+- name: URL
+  url: http://dx.doi.org/10.1038/nrn.2016.167
+---

--- a/content/publications/poldrack-2024/cite.bib
+++ b/content/publications/poldrack-2024/cite.bib
@@ -1,0 +1,56 @@
+@article{poldrack_2024,
+ author = {Poldrack, Russell A. and Markiewicz, Christopher J. and
+Appelhoff, Stefan and Ashar, Yoni K. and Auer, Tibor and
+Baillet, Sylvain and Bansal, Shashank and Beltrachini,
+Leandro and Benar, Christian G. and Bertazzoli, Giacomo and
+Bhogawar, Suyash and Blair, Ross W. and Bortoletto, Marta
+and Boudreau, Mathieu and Brooks, Teon L. and Calhoun,
+Vince D. and Castelli, Filippo Maria and Clement, Patricia
+and Cohen, Alexander L. and Cohen-Adad, Julien and
+D’Ambrosio, Sasha and de Hollander, Gilles and de la
+Iglesia-Vayá, María and de la Vega, Alejandro and
+Delorme, Arnaud and Devinsky, Orrin and Draschkow, Dejan
+and Duff, Eugene Paul and DuPre, Elizabeth and Earl, Eric
+and Esteban, Oscar and Feingold, Franklin W. and Flandin,
+Guillaume and Galassi, Anthony and Gallitto, Giuseppe and
+Ganz, Melanie and Gau, Rémi and Gholam, James and Ghosh,
+Satrajit S. and Giacomel, Alessio and Gillman, Ashley G.
+and Gleeson, Padraig and Gramfort, Alexandre and Guay,
+Samuel and Guidali, Giacomo and Halchenko, Yaroslav O. and
+Handwerker, Daniel A. and Hardcastle, Nell and Herholz,
+Peer and Hermes, Dora and Honey, Christopher J. and Innis,
+Robert B. and Ioanas, Horea-Ioan and Jahn, Andrew and
+Karakuzu, Agah and Keator, David B. and Kiar, Gregory and
+Kincses, Balint and Laird, Angela R. and Lau, Jonathan C.
+and Lazari, Alberto and Legarreta, Jon Haitz and Li, Adam
+and Li, Xiangrui and Love, Bradley C. and Lu, Hanzhang and
+Marcantoni, Eleonora and Maumet, Camille and Mazzamuto,
+Giacomo and Meisler, Steven L. and Mikkelsen, Mark and
+Mutsaerts, Henk and Nichols, Thomas E. and Nikolaidis, Aki
+and Nilsonne, Gustav and Niso, Guiomar and Norgaard, Martin
+and Okell, Thomas W. and Oostenveld, Robert and Ort, Eduard
+and Park, Patrick J. and Pawlik, Mateusz and Pernet, Cyril
+R. and Pestilli, Franco and Petr, Jan and Phillips,
+Christophe and Poline, Jean-Baptiste and Pollonini, Luca
+and Raamana, Pradeep Reddy and Ritter, Petra and Rizzo,
+Gaia and Robbins, Kay A. and Rockhill, Alexander P. and
+Rogers, Christine and Rokem, Ariel and Rorden, Chris and
+Routier, Alexandre and Saborit-Torres, Jose Manuel and
+Salo, Taylor and Schirner, Michael and Smith, Robert E. and
+Spisak, Tamas and Sprenger, Julia and Swann, Nicole C. and
+Szinte, Martin and Takerkart, Sylvain and Thirion, Bertrand
+and Thomas, Adam G. and Torabian, Sajjad and Varoquaux,
+Gael and Voytek, Bradley and Welzel, Julius and Wilson,
+Martin and Yarkoni, Tal and Gorgolewski, Krzysztof J.},
+ doi = {10.1162/imag_a_00103},
+ issn = {2837-6056},
+ journal = {Imaging Neuroscience},
+ month = {March},
+ pages = {1–19},
+ publisher = {MIT Press},
+ title = {The past, present, and future of the brain imaging data
+structure (BIDS)},
+ url = {http://dx.doi.org/10.1162/imag_a_00103},
+ volume = {2},
+ year = {2024}
+}

--- a/content/publications/poldrack-2024/index.md
+++ b/content/publications/poldrack-2024/index.md
@@ -1,0 +1,128 @@
+---
+title: The past, present, and future of the brain imaging data structure (BIDS)
+authors:
+- Russell A. Poldrack
+- Christopher J. Markiewicz
+- Stefan Appelhoff
+- Yoni K. Ashar
+- Tibor Auer
+- Sylvain Baillet
+- Shashank Bansal
+- Leandro Beltrachini
+- Christian G. Benar
+- Giacomo Bertazzoli
+- Suyash Bhogawar
+- Ross W. Blair
+- Marta Bortoletto
+- Mathieu Boudreau
+- Teon L. Brooks
+- Vince D. Calhoun
+- Filippo Maria Castelli
+- Patricia Clement
+- Alexander L. Cohen
+- Julien Cohen-Adad
+- Sasha D’Ambrosio
+- Gilles de Hollander
+- María de la Iglesia-Vayá
+- Alejandro de la Vega
+- Arnaud Delorme
+- Orrin Devinsky
+- Dejan Draschkow
+- Eugene Paul Duff
+- Elizabeth DuPre
+- Eric Earl
+- Oscar Esteban
+- Franklin W. Feingold
+- Guillaume Flandin
+- Anthony Galassi
+- Giuseppe Gallitto
+- Melanie Ganz
+- Rémi Gau
+- James Gholam
+- Satrajit S. Ghosh
+- Alessio Giacomel
+- Ashley G. Gillman
+- Padraig Gleeson
+- Alexandre Gramfort
+- Samuel Guay
+- Giacomo Guidali
+- Yaroslav O. Halchenko
+- Daniel A. Handwerker
+- Nell Hardcastle
+- Peer Herholz
+- Dora Hermes
+- Christopher J. Honey
+- Robert B. Innis
+- Horea-Ioan Ioanas
+- Andrew Jahn
+- Agah Karakuzu
+- David B. Keator
+- Gregory Kiar
+- Balint Kincses
+- Angela R. Laird
+- Jonathan C. Lau
+- Alberto Lazari
+- Jon Haitz Legarreta
+- Adam Li
+- Xiangrui Li
+- Bradley C. Love
+- Hanzhang Lu
+- Eleonora Marcantoni
+- Camille Maumet
+- Giacomo Mazzamuto
+- Steven L. Meisler
+- Mark Mikkelsen
+- Henk Mutsaerts
+- Thomas E. Nichols
+- Aki Nikolaidis
+- Gustav Nilsonne
+- Guiomar Niso
+- Martin Norgaard
+- Thomas W. Okell
+- Robert Oostenveld
+- Eduard Ort
+- Patrick J. Park
+- Mateusz Pawlik
+- Cyril R. Pernet
+- Franco Pestilli
+- Jan Petr
+- Christophe Phillips
+- Jean-Baptiste Poline
+- Luca Pollonini
+- Pradeep Reddy Raamana
+- Petra Ritter
+- Gaia Rizzo
+- Kay A. Robbins
+- Alexander P. Rockhill
+- Christine Rogers
+- Ariel Rokem
+- Chris Rorden
+- Alexandre Routier
+- Jose Manuel Saborit-Torres
+- Taylor Salo
+- Michael Schirner
+- Robert E. Smith
+- Tamas Spisak
+- Julia Sprenger
+- Nicole C. Swann
+- Martin Szinte
+- Sylvain Takerkart
+- Bertrand Thirion
+- Adam G. Thomas
+- Sajjad Torabian
+- Gael Varoquaux
+- Bradley Voytek
+- Julius Welzel
+- Martin Wilson
+- Tal Yarkoni
+- Krzysztof J. Gorgolewski
+date: '2024-03-01'
+publishDate: '2024-12-19T23:16:36.688055Z'
+publication_types:
+- article-journal
+publication: '*Imaging Neuroscience*'
+doi: 10.1162/imag_a_00103
+links:
+- name: URL
+  url: http://dx.doi.org/10.1162/imag_a_00103
+---

--- a/content/publications/poline-2019/cite.bib
+++ b/content/publications/poline-2019/cite.bib
@@ -1,0 +1,13 @@
+@article{poline_2019,
+ author = {Poline, Jean-Baptiste},
+ doi = {10.12688/mniopenres.12772.2},
+ issn = {2515-5059},
+ journal = {MNI Open Research},
+ month = {January},
+ pages = {1},
+ publisher = {F1000 Research Ltd},
+ title = {From data sharing to data publishing},
+ url = {http://dx.doi.org/10.12688/mniopenres.12772.2},
+ volume = {2},
+ year = {2019}
+}

--- a/content/publications/poline-2019/index.md
+++ b/content/publications/poline-2019/index.md
@@ -1,0 +1,14 @@
+---
+title: From data sharing to data publishing
+authors:
+- Jean-Baptiste Poline
+date: '2019-01-01'
+publishDate: '2024-12-19T23:16:36.694105Z'
+publication_types:
+- article-journal
+publication: '*MNI Open Research*'
+doi: 10.12688/mniopenres.12772.2
+links:
+- name: URL
+  url: http://dx.doi.org/10.12688/mniopenres.12772.2
+---

--- a/content/publications/poline-2022/cite.bib
+++ b/content/publications/poline-2022/cite.bib
@@ -1,0 +1,21 @@
+@article{poline_2022,
+ author = {Poline, Jean-Baptiste and Kennedy, David N. and Sommer,
+Friedrich T. and Ascoli, Giorgio A. and Van Essen, David C.
+and Ferguson, Adam R. and Grethe, Jeffrey S. and Hawrylycz,
+Michael J. and Thompson, Paul M. and Poldrack, Russell A.
+and Ghosh, Satrajit S. and Keator, David B. and Athey,
+Thomas L. and Vogelstein, Joshua T. and Mayberg, Helen S.
+and Martone, Maryann E.},
+ doi = {10.1007/s12021-021-09557-0},
+ issn = {1559-0089},
+ journal = {Neuroinformatics},
+ month = {January},
+ number = {2},
+ pages = {507–512},
+ publisher = {Springer Science and Business Media LLC},
+ title = {Is Neuroscience FAIR? A Call for Collaborative
+Standardisation of Neuroscience Data},
+ url = {http://dx.doi.org/10.1007/s12021-021-09557-0},
+ volume = {20},
+ year = {2022}
+}

--- a/content/publications/poline-2022/index.md
+++ b/content/publications/poline-2022/index.md
@@ -1,0 +1,30 @@
+---
+title: Is Neuroscience FAIR? A Call for Collaborative Standardisation of Neuroscience
+  Data
+authors:
+- Jean-Baptiste Poline
+- David N. Kennedy
+- Friedrich T. Sommer
+- Giorgio A. Ascoli
+- David C. Van Essen
+- Adam R. Ferguson
+- Jeffrey S. Grethe
+- Michael J. Hawrylycz
+- Paul M. Thompson
+- Russell A. Poldrack
+- Satrajit S. Ghosh
+- David B. Keator
+- Thomas L. Athey
+- Joshua T. Vogelstein
+- Helen S. Mayberg
+- Maryann E. Martone
+date: '2022-01-01'
+publishDate: '2024-12-19T23:16:36.697909Z'
+publication_types:
+- article-journal
+publication: '*Neuroinformatics*'
+doi: 10.1007/s12021-021-09557-0
+links:
+- name: URL
+  url: http://dx.doi.org/10.1007/s12021-021-09557-0
+---

--- a/content/publications/poline-2023/cite.bib
+++ b/content/publications/poline-2023/cite.bib
@@ -1,0 +1,29 @@
+@article{poline_2023,
+ author = {Poline, Jean-Baptiste and Das, Samir and Glatard, Tristan
+and Madjar, Cécile and Dickie, Erin W. and Lecours, Xavier
+and Beaudry, Thomas and Beck, Natacha and Behan, Brendan
+and Brown, Shawn T. and Bujold, David and Beauvais, Michael
+and Caron, Bryan and Czech, Candice and Dharsee, Moyez and
+Dugré, Mathieu and Evans, Ken and Gee, Tom and Ippoliti,
+Giulia and Kiar, Gregory and Knoppers, Bartha Maria and
+Kuehn, Tristan and Le, Diana and Lo, Derek and Mazaheri,
+Mandana and MacFarlane, Dave and Muja, Naser and O’Brien,
+Emmet A. and O’Callaghan, Liam and Paiva, Santiago and
+Park, Patrick and Quesnel, Darcy and Rabelais, Henri and
+Rioux, Pierre and Legault, Mélanie and Tremblay-Mercier,
+Jennifer and Rotenberg, David and Stone, Jessica and
+Strauss, Ted and Zaytseva, Ksenia and Zhou, Joey and
+Duchesne, Simon and Khan, Ali R. and Hill, Sean and Evans,
+Alan C.},
+ doi = {10.1038/s41597-023-01946-1},
+ issn = {2052-4463},
+ journal = {Scientific Data},
+ month = {April},
+ number = {1},
+ publisher = {Springer Science and Business Media LLC},
+ title = {Data and Tools Integration in the Canadian Open
+Neuroscience Platform},
+ url = {http://dx.doi.org/10.1038/s41597-023-01946-1},
+ volume = {10},
+ year = {2023}
+}

--- a/content/publications/poline-2023/index.md
+++ b/content/publications/poline-2023/index.md
@@ -1,0 +1,58 @@
+---
+title: Data and Tools Integration in the Canadian Open Neuroscience Platform
+authors:
+- Jean-Baptiste Poline
+- Samir Das
+- Tristan Glatard
+- Cécile Madjar
+- Erin W. Dickie
+- Xavier Lecours
+- Thomas Beaudry
+- Natacha Beck
+- Brendan Behan
+- Shawn T. Brown
+- David Bujold
+- Michael Beauvais
+- Bryan Caron
+- Candice Czech
+- Moyez Dharsee
+- Mathieu Dugré
+- Ken Evans
+- Tom Gee
+- Giulia Ippoliti
+- Gregory Kiar
+- Bartha Maria Knoppers
+- Tristan Kuehn
+- Diana Le
+- Derek Lo
+- Mandana Mazaheri
+- Dave MacFarlane
+- Naser Muja
+- Emmet A. O’Brien
+- Liam O’Callaghan
+- Santiago Paiva
+- Patrick Park
+- Darcy Quesnel
+- Henri Rabelais
+- Pierre Rioux
+- Mélanie Legault
+- Jennifer Tremblay-Mercier
+- David Rotenberg
+- Jessica Stone
+- Ted Strauss
+- Ksenia Zaytseva
+- Joey Zhou
+- Simon Duchesne
+- Ali R. Khan
+- Sean Hill
+- Alan C. Evans
+date: '2023-04-01'
+publishDate: '2024-12-19T23:16:36.702002Z'
+publication_types:
+- article-journal
+publication: '*Scientific Data*'
+doi: 10.1038/s41597-023-01946-1
+links:
+- name: URL
+  url: http://dx.doi.org/10.1038/s41597-023-01946-1
+---

--- a/content/publications/publications.bib
+++ b/content/publications/publications.bib
@@ -1,0 +1,2265 @@
+
+@Article{	  abrams_2021,
+  title		= {A Standards Organization for Open and FAIR Neuroscience:
+		  the International Neuroinformatics Coordinating Facility},
+  volume	= {20},
+  issn		= {1559-0089},
+  url		= {http://dx.doi.org/10.1007/s12021-020-09509-0},
+  doi		= {10.1007/s12021-020-09509-0},
+  number	= {1},
+  journal	= {Neuroinformatics},
+  publisher	= {Springer Science and Business Media LLC},
+  author	= {Abrams, Mathew Birdsall and Bjaalie, Jan G. and Das, Samir
+		  and Egan, Gary F. and Ghosh, Satrajit S. and Goscinski,
+		  Wojtek J. and Grethe, Jeffrey S. and Kotaleski, Jeanette
+		  Hellgren and Ho, Eric Tatt Wei and Kennedy, David N. and
+		  Lanyon, Linda J. and Leergaard, Trygve B. and Mayberg,
+		  Helen S. and Milanesi, Luciano and Mouček, Roman and
+		  Poline, J. B. and Roy, Prasun K. and Strother, Stephen C.
+		  and Tang, Tong Boon and Tiesinga, Paul and Wachtler, Thomas
+		  and Wójcik, Daniel K. and Martone, Maryann E.},
+  year		= {2021},
+  month		= jan,
+  pages		= {25–36}
+}
+
+@Article{	  abrams_2021,
+  title		= {Correction to: A Standards Organization for Open and FAIR
+		  Neuroscience: the International Neuroinformatics
+		  Coordinating Facility},
+  volume	= {20},
+  issn		= {1559-0089},
+  url		= {http://dx.doi.org/10.1007/s12021-021-09522-x},
+  doi		= {10.1007/s12021-021-09522-x},
+  number	= {1},
+  journal	= {Neuroinformatics},
+  publisher	= {Springer Science and Business Media LLC},
+  author	= {Abrams, Mathew Birdsall and Bjaalie, Jan G. and Das, Samir
+		  and Egan, Gary F. and Ghosh, Satrajit S. and Goscinski,
+		  Wojtek J. and Grethe, Jeffrey S. and Kotaleski, Jeanette
+		  Hellgren and Ho, Eric Tatt Wei and Kennedy, David N. and
+		  Lanyon, Linda J. and Leergaard, Trygve B. and Mayberg,
+		  Helen S. and Milanesi, Luciano and Mouček, Roman and
+		  Poline, J. B. and Roy, Prasun K. and Strother, Stephen C.
+		  and Tang, Tong Boon and Tiesinga, Paul and Wachtler, Thomas
+		  and Wójcik, Daniel K. and Martone, Maryann E.},
+  year		= {2021},
+  month		= apr,
+  pages		= {37–38}
+}
+
+@Article{	  bandrowski_2016,
+  title		= {RRIDs: A Simple Step toward Improving Reproducibility
+		  through Rigor and Transparency of Experimental Methods},
+  volume	= {90},
+  issn		= {0896-6273},
+  url		= {http://dx.doi.org/10.1016/j.neuron.2016.04.030},
+  doi		= {10.1016/j.neuron.2016.04.030},
+  number	= {3},
+  journal	= {Neuron},
+  publisher	= {Elsevier BV},
+  author	= {Bandrowski, Anita E. and Martone, Maryann E.},
+  year		= {2016},
+  month		= may,
+  pages		= {434–436}
+}
+
+@Article{	  bannier_2021,
+  title		= {The Open Brain Consent: Informing research participants
+		  and obtaining consent to share brain imaging data},
+  volume	= {42},
+  issn		= {1097-0193},
+  url		= {http://dx.doi.org/10.1002/hbm.25351},
+  doi		= {10.1002/hbm.25351},
+  number	= {7},
+  journal	= {Human Brain Mapping},
+  publisher	= {Wiley},
+  author	= {Bannier, Elise and Barker, Gareth and Borghesani,
+		  Valentina and Broeckx, Nils and Clement, Patricia and
+		  Emblem, Kyrre E. and Ghosh, Satrajit and Glerean, Enrico
+		  and Gorgolewski, Krzysztof J. and Havu, Marko and
+		  Halchenko, Yaroslav O. and Herholz, Peer and Hespel, Anne
+		  and Heunis, Stephan and Hu, Yue and Hu, Chuan‐Peng and
+		  Huijser, Dorien and de la Iglesia Vayá, María and
+		  Jancalek, Radim and Katsaros, Vasileios K. and Kieseler,
+		  Marie‐Luise and Maumet, Camille and Moreau, Clara A. and
+		  Mutsaerts, Henk‐Jan and Oostenveld, Robert and
+		  Ozturk‐Isik, Esin and Pascual Leone Espinosa, Nicolas and
+		  Pellman, John and Pernet, Cyril R and Pizzini, Francesca
+		  Benedetta and Trbalić, Amira Šerifović and Toussaint,
+		  Paule‐Joanne and Visconti di Oleggio Castello, Matteo and
+		  Wang, Fengjuan and Wang, Cheng and Zhu, Hua},
+  year		= {2021},
+  month		= feb,
+  pages		= {1945–1951}
+}
+
+@Article{	  baranger_2021,
+  title		= {Protocol for a machine learning algorithm predicting
+		  depressive disorders using the T1w/T2w ratio},
+  volume	= {8},
+  issn		= {2215-0161},
+  url		= {http://dx.doi.org/10.1016/j.mex.2021.101595},
+  doi		= {10.1016/j.mex.2021.101595},
+  journal	= {MethodsX},
+  publisher	= {Elsevier BV},
+  author	= {Baranger, David A.A. and Halchenko, Yaroslav O. and Satz,
+		  Skye and Ragozzino, Rachel and Iyengar, Satish and Swartz,
+		  Holly A. and Manelis, Anna},
+  year		= {2021},
+  pages		= {101595}
+}
+
+@Article{	  baranger_2021,
+  title		= {Aberrant levels of cortical myelin distinguish individuals
+		  with depressive disorders from healthy controls},
+  volume	= {32},
+  issn		= {2213-1582},
+  url		= {http://dx.doi.org/10.1016/j.nicl.2021.102790},
+  doi		= {10.1016/j.nicl.2021.102790},
+  journal	= {NeuroImage: Clinical},
+  publisher	= {Elsevier BV},
+  author	= {Baranger, David A.A. and Halchenko, Yaroslav O. and Satz,
+		  Skye and Ragozzino, Rachel and Iyengar, Satish and Swartz,
+		  Holly A. and Manelis, Anna},
+  year		= {2021},
+  pages		= {102790}
+}
+
+@Article{	  bazeille_2021,
+  title		= {An empirical evaluation of functional alignment using
+		  inter-subject decoding},
+  volume	= {245},
+  issn		= {1053-8119},
+  url		= {http://dx.doi.org/10.1016/j.neuroimage.2021.118683},
+  doi		= {10.1016/j.neuroimage.2021.118683},
+  journal	= {NeuroImage},
+  publisher	= {Elsevier BV},
+  author	= {Bazeille, Thomas and DuPre, Elizabeth and Richard, Hugo
+		  and Poline, Jean-Baptiste and Thirion, Bertrand},
+  year		= {2021},
+  month		= dec,
+  pages		= {118683}
+}
+
+@Article{	  bhagwat_2021,
+  title		= {Understanding the impact of preprocessing pipelines on
+		  neuroimaging cortical surface analyses},
+  volume	= {10},
+  issn		= {2047-217X},
+  url		= {http://dx.doi.org/10.1093/gigascience/giaa155},
+  doi		= {10.1093/gigascience/giaa155},
+  number	= {1},
+  journal	= {GigaScience},
+  publisher	= {Oxford University Press (OUP)},
+  author	= {Bhagwat, Nikhil and Barry, Amadou and Dickie, Erin W and
+		  Brown, Shawn T and Devenyi, Gabriel A and Hatano, Koji and
+		  DuPre, Elizabeth and Dagher, Alain and Chakravarty, Mallar
+		  and Greenwood, Celia M T and Misic, Bratislav and Kennedy,
+		  David N and Poline, Jean-Baptiste},
+  year		= {2021},
+  month		= jan
+}
+
+@Article{	  boaro_2022,
+  title		= {Deep neural networks allow expert-level brain meningioma
+		  segmentation and present potential for improvement of
+		  clinical practice},
+  volume	= {12},
+  issn		= {2045-2322},
+  url		= {http://dx.doi.org/10.1038/s41598-022-19356-5},
+  doi		= {10.1038/s41598-022-19356-5},
+  number	= {1},
+  journal	= {Scientific Reports},
+  publisher	= {Springer Science and Business Media LLC},
+  author	= {Boaro, Alessandro and Kaczmarzyk, Jakub R. and Kavouridis,
+		  Vasileios K. and Harary, Maya and Mammi, Marco and Dawood,
+		  Hassan and Shea, Alice and Cho, Elise Y. and Juvekar,
+		  Parikshit and Noh, Thomas and Rana, Aakanksha and Ghosh,
+		  Satrajit and Arnaout, Omar},
+  year		= {2022},
+  month		= sep
+}
+
+@Article{	  bollmann_2023,
+  title		= {Neurodesk: An accessible, flexible, and portable data
+		  analysis environment for reproducible neuroimaging},
+  url		= {http://dx.doi.org/10.21203/rs.3.rs-2649734/v1},
+  doi		= {10.21203/rs.3.rs-2649734/v1},
+  publisher	= {Research Square Platform LLC},
+  author	= {Bollmann, Steffen and Renton, Angela and Dao, Thuy and
+		  Johnstone, Tom and Civier, Oren and Sullivan, Ryan and
+		  White, David and Lyons, Paris and Slade, Benjamin and
+		  Abbott, David and Amos, Toluwani and Bollmann, Saskia and
+		  Botting, Andy and Campbell, Megan and Chang, Jeryn and
+		  Close, Thomas and Eckstein, Korbinian and Egan, Gary and
+		  Evas, Stefanie and Flandin, Guillaume and Garner, Kelly and
+		  Garrido, Marta and Ghosh, Satrajit and Grignard, Martin and
+		  Hannan, Anthony and Huber, Laurentius (Renzo) and
+		  Kaczmarzyk, Jakub and Kasper, Lars and Kuhlmann, Levin and
+		  Lou, Kexin and Mantilla-Ramos, Yorguin-Jose and Mattingley,
+		  Jason and Morris, Jo and Narayanan, Akshaiy and Pestilli,
+		  Franco and Puce, Aina and Ribeiro, Fernanda and Rogasch,
+		  Nigel and Rorden, Chris and Schira, Mark and Shaw, Thomas
+		  and Sowman, Paul and Spitz, Gershon and Stewart, Ashley and
+		  Ye, Xincheng and Zhu, Judy and Hughes, Matthew and
+		  Narayanan, Aswin},
+  year		= {2023},
+  month		= mar
+}
+
+@Article{	  botvinik_nezer_2020,
+  title		= {Variability in the analysis of a single neuroimaging
+		  dataset by many teams},
+  volume	= {582},
+  issn		= {1476-4687},
+  url		= {http://dx.doi.org/10.1038/s41586-020-2314-9},
+  doi		= {10.1038/s41586-020-2314-9},
+  number	= {7810},
+  journal	= {Nature},
+  publisher	= {Springer Science and Business Media LLC},
+  author	= {Botvinik-Nezer, Rotem and Holzmeister, Felix and Camerer,
+		  Colin F. and Dreber, Anna and Huber, Juergen and
+		  Johannesson, Magnus and Kirchler, Michael and Iwanir, Roni
+		  and Mumford, Jeanette A. and Adcock, R. Alison and Avesani,
+		  Paolo and Baczkowski, Blazej M. and Bajracharya, Aahana and
+		  Bakst, Leah and Ball, Sheryl and Barilari, Marco and Bault,
+		  Nadège and Beaton, Derek and Beitner, Julia and Benoit,
+		  Roland G. and Berkers, Ruud M. W. J. and Bhanji, Jamil P.
+		  and Biswal, Bharat B. and Bobadilla-Suarez, Sebastian and
+		  Bortolini, Tiago and Bottenhorn, Katherine L. and Bowring,
+		  Alexander and Braem, Senne and Brooks, Hayley R. and
+		  Brudner, Emily G. and Calderon, Cristian B. and Camilleri,
+		  Julia A. and Castrellon, Jaime J. and Cecchetti, Luca and
+		  Cieslik, Edna C. and Cole, Zachary J. and Collignon,
+		  Olivier and Cox, Robert W. and Cunningham, William A. and
+		  Czoschke, Stefan and Dadi, Kamalaker and Davis, Charles P.
+		  and Luca, Alberto De and Delgado, Mauricio R. and
+		  Demetriou, Lysia and Dennison, Jeffrey B. and Di, Xin and
+		  Dickie, Erin W. and Dobryakova, Ekaterina and Donnat,
+		  Claire L. and Dukart, Juergen and Duncan, Niall W. and
+		  Durnez, Joke and Eed, Amr and Eickhoff, Simon B. and
+		  Erhart, Andrew and Fontanesi, Laura and Fricke, G. Matthew
+		  and Fu, Shiguang and Galván, Adriana and Gau, Remi and
+		  Genon, Sarah and Glatard, Tristan and Glerean, Enrico and
+		  Goeman, Jelle J. and Golowin, Sergej A. E. and
+		  González-García, Carlos and Gorgolewski, Krzysztof J. and
+		  Grady, Cheryl L. and Green, Mikella A. and Guassi Moreira,
+		  João F. and Guest, Olivia and Hakimi, Shabnam and
+		  Hamilton, J. Paul and Hancock, Roeland and Handjaras,
+		  Giacomo and Harry, Bronson B. and Hawco, Colin and Herholz,
+		  Peer and Herman, Gabrielle and Heunis, Stephan and
+		  Hoffstaedter, Felix and Hogeveen, Jeremy and Holmes, Susan
+		  and Hu, Chuan-Peng and Huettel, Scott A. and Hughes,
+		  Matthew E. and Iacovella, Vittorio and Iordan, Alexandru D.
+		  and Isager, Peder M. and Isik, Ayse I. and Jahn, Andrew and
+		  Johnson, Matthew R. and Johnstone, Tom and Joseph, Michael
+		  J. E. and Juliano, Anthony C. and Kable, Joseph W. and
+		  Kassinopoulos, Michalis and Koba, Cemal and Kong,
+		  Xiang-Zhen and Koscik, Timothy R. and Kucukboyaci, Nuri
+		  Erkut and Kuhl, Brice A. and Kupek, Sebastian and Laird,
+		  Angela R. and Lamm, Claus and Langner, Robert and
+		  Lauharatanahirun, Nina and Lee, Hongmi and Lee, Sangil and
+		  Leemans, Alexander and Leo, Andrea and Lesage, Elise and
+		  Li, Flora and Li, Monica Y. C. and Lim, Phui Cheng and
+		  Lintz, Evan N. and Liphardt, Schuyler W. and Losecaat
+		  Vermeer, Annabel B. and Love, Bradley C. and Mack, Michael
+		  L. and Malpica, Norberto and Marins, Theo and Maumet,
+		  Camille and McDonald, Kelsey and McGuire, Joseph T. and
+		  Melero, Helena and Méndez Leal, Adriana S. and Meyer,
+		  Benjamin and Meyer, Kristin N. and Mihai, Glad and Mitsis,
+		  Georgios D. and Moll, Jorge and Nielson, Dylan M. and
+		  Nilsonne, Gustav and Notter, Michael P. and Olivetti,
+		  Emanuele and Onicas, Adrian I. and Papale, Paolo and Patil,
+		  Kaustubh R. and Peelle, Jonathan E. and Pérez, Alexandre
+		  and Pischedda, Doris and Poline, Jean-Baptiste and
+		  Prystauka, Yanina and Ray, Shruti and Reuter-Lorenz,
+		  Patricia A. and Reynolds, Richard C. and Ricciardi,
+		  Emiliano and Rieck, Jenny R. and Rodriguez-Thompson, Anais
+		  M. and Romyn, Anthony and Salo, Taylor and Samanez-Larkin,
+		  Gregory R. and Sanz-Morales, Emilio and Schlichting,
+		  Margaret L. and Schultz, Douglas H. and Shen, Qiang and
+		  Sheridan, Margaret A. and Silvers, Jennifer A. and
+		  Skagerlund, Kenny and Smith, Alec and Smith, David V. and
+		  Sokol-Hessner, Peter and Steinkamp, Simon R. and Tashjian,
+		  Sarah M. and Thirion, Bertrand and Thorp, John N. and
+		  Tinghög, Gustav and Tisdall, Loreen and Tompson, Steven H.
+		  and Toro-Serey, Claudio and Torre Tresols, Juan Jesus and
+		  Tozzi, Leonardo and Truong, Vuong and Turella, Luca and van
+		  ‘t Veer, Anna E. and Verguts, Tom and Vettel, Jean M. and
+		  Vijayarajah, Sagana and Vo, Khoi and Wall, Matthew B. and
+		  Weeda, Wouter D. and Weis, Susanne and White, David J. and
+		  Wisniewski, David and Xifra-Porxas, Alba and Yearling,
+		  Emily A. and Yoon, Sangsuk and Yuan, Rui and Yuen, Kenneth
+		  S. L. and Zhang, Lei and Zhang, Xu and Zosky, Joshua E. and
+		  Nichols, Thomas E. and Poldrack, Russell A. and Schonberg,
+		  Tom},
+  year		= {2020},
+  month		= may,
+  pages		= {84–88}
+}
+
+@Article{	  burdinski_2024,
+  title		= {Impact of year-long cannabis use for medical symptoms on
+		  brain activation during cognitive processes},
+  url		= {http://dx.doi.org/10.1101/2024.04.29.24306516},
+  doi		= {10.1101/2024.04.29.24306516},
+  publisher	= {Cold Spring Harbor Laboratory},
+  author	= {Burdinski, Debbie and Kodibagkar, Alisha and Potter, Kevin
+		  and Schuster, Randi and Evins, A. Eden and Ghosh, Satrajit
+		  and Gilman, Jodi},
+  year		= {2024},
+  month		= may
+}
+
+@Article{	  charles_2020,
+  title		= {Toward Community-Driven Big Open Brain Science: Open Big
+		  Data and Tools for Structure, Function, and Genetics},
+  volume	= {43},
+  issn		= {1545-4126},
+  url		= {http://dx.doi.org/10.1146/annurev-neuro-100119-110036},
+  doi		= {10.1146/annurev-neuro-100119-110036},
+  number	= {1},
+  journal	= {Annual Review of Neuroscience},
+  publisher	= {Annual Reviews},
+  author	= {Charles, Adam S. and Falk, Benjamin and Turner, Nicholas
+		  and Pereira, Talmo D. and Tward, Daniel and Pedigo,
+		  Benjamin D. and Chung, Jaewon and Burns, Randal and Ghosh,
+		  Satrajit S. and Kebschull, Justus M. and Silversmith,
+		  William and Vogelstein, Joshua T.},
+  year		= {2020},
+  month		= jul,
+  pages		= {441–464}
+}
+
+@Article{	  cheng_2020,
+  title		= {A new virtue of phantom MRI data: explaining variance in
+		  human participant data},
+  volume	= {9},
+  issn		= {2046-1402},
+  url		= {http://dx.doi.org/10.12688/f1000research.24544.1},
+  doi		= {10.12688/f1000research.24544.1},
+  journal	= {F1000Research},
+  publisher	= {F1000 Research Ltd},
+  author	= {Cheng, Christopher P. and Halchenko, Yaroslav O.},
+  year		= {2020},
+  month		= sep,
+  pages		= {1131}
+}
+
+@Article{	  ciric_2022,
+  title		= {TemplateFlow: FAIR-sharing of multi-scale, multi-species
+		  brain models},
+  volume	= {19},
+  issn		= {1548-7105},
+  url		= {http://dx.doi.org/10.1038/s41592-022-01681-2},
+  doi		= {10.1038/s41592-022-01681-2},
+  number	= {12},
+  journal	= {Nature Methods},
+  publisher	= {Springer Science and Business Media LLC},
+  author	= {Ciric, Rastko and Thompson, William H. and Lorenz, Romy
+		  and Goncalves, Mathias and MacNicol, Eilidh E. and
+		  Markiewicz, Christopher J. and Halchenko, Yaroslav O. and
+		  Ghosh, Satrajit S. and Gorgolewski, Krzysztof J. and
+		  Poldrack, Russell A. and Esteban, Oscar},
+  year		= {2022},
+  month		= dec,
+  pages		= {1568–1571}
+}
+
+@Article{	  cruces_2022,
+  title		= {Micapipe: A pipeline for multimodal neuroimaging and
+		  connectome analysis},
+  volume	= {263},
+  issn		= {1053-8119},
+  url		= {http://dx.doi.org/10.1016/j.neuroimage.2022.119612},
+  doi		= {10.1016/j.neuroimage.2022.119612},
+  journal	= {NeuroImage},
+  publisher	= {Elsevier BV},
+  author	= {Cruces, Raúl R. and Royer, Jessica and Herholz, Peer and
+		  Larivière, Sara and Vos de Wael, Reinder and Paquola,
+		  Casey and Benkarim, Oualid and Park, Bo-yong and
+		  Degré-Pelletier, Janie and Nelson, Mark C. and DeKraker,
+		  Jordan and Leppert, Ilana R. and Tardif, Christine and
+		  Poline, Jean-Baptiste and Concha, Luis and Bernhardt, Boris
+		  C.},
+  year		= {2022},
+  month		= nov,
+  pages		= {119612}
+}
+
+@Article{	  de_la_vega_2022,
+  title		= {Neuroscout, a unified platform for generalizable and
+		  reproducible fMRI research},
+  volume	= {11},
+  issn		= {2050-084X},
+  url		= {http://dx.doi.org/10.7554/elife.79277},
+  doi		= {10.7554/elife.79277},
+  journal	= {eLife},
+  publisher	= {eLife Sciences Publications, Ltd},
+  author	= {de la Vega, Alejandro and Rocca, Roberta and Blair, Ross W
+		  and Markiewicz, Christopher J and Mentch, Jeff and Kent,
+		  James D and Herholz, Peer and Ghosh, Satrajit S and
+		  Poldrack, Russell A and Yarkoni, Tal},
+  year		= {2022},
+  month		= aug
+}
+
+@Article{	  dock_s_2021,
+  title		= {Preventing dataset shift from breaking machine-learning
+		  biomarkers},
+  volume	= {10},
+  issn		= {2047-217X},
+  url		= {http://dx.doi.org/10.1093/gigascience/giab055},
+  doi		= {10.1093/gigascience/giab055},
+  number	= {9},
+  journal	= {GigaScience},
+  publisher	= {Oxford University Press (OUP)},
+  author	= {Dockès, Jérôme and Varoquaux, Gaël and Poline,
+		  Jean-Baptiste},
+  year		= {2021},
+  month		= sep
+}
+
+@Article{	  dupre_2020,
+  title		= {Nature abhors a paywall: How open science can realize the
+		  potential of naturalistic stimuli},
+  volume	= {216},
+  issn		= {1053-8119},
+  url		= {http://dx.doi.org/10.1016/j.neuroimage.2019.116330},
+  doi		= {10.1016/j.neuroimage.2019.116330},
+  journal	= {NeuroImage},
+  publisher	= {Elsevier BV},
+  author	= {DuPre, Elizabeth and Hanke, Michael and Poline,
+		  Jean-Baptiste},
+  year		= {2020},
+  month		= aug,
+  pages		= {116330}
+}
+
+@Article{	  dupre_2022,
+  title		= {Beyond advertising: New infrastructures for publishing
+		  integrated research objects},
+  volume	= {18},
+  issn		= {1553-7358},
+  url		= {http://dx.doi.org/10.1371/journal.pcbi.1009651},
+  doi		= {10.1371/journal.pcbi.1009651},
+  number	= {1},
+  journal	= {PLOS Computational Biology},
+  publisher	= {Public Library of Science (PLoS)},
+  author	= {DuPre, Elizabeth and Holdgraf, Chris and Karakuzu, Agah
+		  and Tetrel, Loïc and Bellec, Pierre and Stikov, Nikola and
+		  Poline, Jean-Baptiste},
+  editor	= {Mac Gabhann, Feilim},
+  year		= {2022},
+  month		= jan,
+  pages		= {e1009651}
+}
+
+@Article{	  eglen_2017,
+  title		= {Toward standard practices for sharing computer code and
+		  programs in neuroscience},
+  volume	= {20},
+  issn		= {1546-1726},
+  url		= {http://dx.doi.org/10.1038/nn.4550},
+  doi		= {10.1038/nn.4550},
+  number	= {6},
+  journal	= {Nature Neuroscience},
+  publisher	= {Springer Science and Business Media LLC},
+  author	= {Eglen, Stephen J and Marwick, Ben and Halchenko, Yaroslav
+		  O and Hanke, Michael and Sufi, Shoaib and Gleeson, Padraig
+		  and Silver, R Angus and Davison, Andrew P and Lanyon, Linda
+		  and Abrams, Mathew and Wachtler, Thomas and Willshaw, David
+		  J and Pouzat, Christophe and Poline, Jean-Baptiste},
+  year		= {2017},
+  month		= jun,
+  pages		= {770–773}
+}
+
+@Article{	  eke_2022,
+  title		= {International data governance for neuroscience},
+  volume	= {110},
+  issn		= {0896-6273},
+  url		= {http://dx.doi.org/10.1016/j.neuron.2021.11.017},
+  doi		= {10.1016/j.neuron.2021.11.017},
+  number	= {4},
+  journal	= {Neuron},
+  publisher	= {Elsevier BV},
+  author	= {Eke, Damian O. and Bernard, Amy and Bjaalie, Jan G. and
+		  Chavarriaga, Ricardo and Hanakawa, Takashi and Hannan,
+		  Anthony J. and Hill, Sean L. and Martone, Maryann E. and
+		  McMahon, Agnes and Ruebel, Oliver and Crook, Sharon and
+		  Thiels, Edda and Pestilli, Franco},
+  year		= {2022},
+  month		= feb,
+  pages		= {600–612}
+}
+
+@Article{	  esteban_2020,
+  title		= {Analysis of task-based functional MRI data preprocessed
+		  with fMRIPrep},
+  volume	= {15},
+  issn		= {1750-2799},
+  url		= {http://dx.doi.org/10.1038/s41596-020-0327-3},
+  doi		= {10.1038/s41596-020-0327-3},
+  number	= {7},
+  journal	= {Nature Protocols},
+  publisher	= {Springer Science and Business Media LLC},
+  author	= {Esteban, Oscar and Ciric, Rastko and Finc, Karolina and
+		  Blair, Ross W. and Markiewicz, Christopher J. and Moodie,
+		  Craig A. and Kent, James D. and Goncalves, Mathias and
+		  DuPre, Elizabeth and Gomez, Daniel E. P. and Ye, Zhifang
+		  and Salo, Taylor and Valabregue, Romain and Amlien, Inge K.
+		  and Liem, Franziskus and Jacoby, Nir and Stojić, Hrvoje
+		  and Cieslak, Matthew and Urchs, Sebastian and Halchenko,
+		  Yaroslav O. and Ghosh, Satrajit S. and De La Vega,
+		  Alejandro and Yarkoni, Tal and Wright, Jessey and Thompson,
+		  William H. and Poldrack, Russell A. and Gorgolewski,
+		  Krzysztof J.},
+  year		= {2020},
+  month		= jun,
+  pages		= {2186–2202}
+}
+
+@Article{	  fenner_2019,
+  title		= {A data citation roadmap for scholarly data repositories},
+  volume	= {6},
+  issn		= {2052-4463},
+  url		= {http://dx.doi.org/10.1038/s41597-019-0031-8},
+  doi		= {10.1038/s41597-019-0031-8},
+  number	= {1},
+  journal	= {Scientific Data},
+  publisher	= {Springer Science and Business Media LLC},
+  author	= {Fenner, Martin and Crosas, Mercè and Grethe, Jeffrey S.
+		  and Kennedy, David and Hermjakob, Henning and Rocca-Serra,
+		  Phillippe and Durand, Gustavo and Berjon, Robin and
+		  Karcher, Sebastian and Martone, Maryann and Clark, Tim},
+  year		= {2019},
+  month		= apr
+}
+
+@Article{	  ferris_2023,
+  title		= {Optimizing automated white matter hyperintensity
+		  segmentation in individuals with stroke},
+  volume	= {2},
+  issn		= {2813-1193},
+  url		= {http://dx.doi.org/10.3389/fnimg.2023.1099301},
+  doi		= {10.3389/fnimg.2023.1099301},
+  journal	= {Frontiers in Neuroimaging},
+  publisher	= {Frontiers Media SA},
+  author	= {Ferris, Jennifer K. and Lo, Bethany P. and Khlif, Mohamed
+		  Salah and Brodtmann, Amy and Boyd, Lara A. and Liew,
+		  Sook-Lei},
+  year		= {2023},
+  month		= mar
+}
+
+@Article{	  fitzpatrick_2019,
+  title		= {Alpha band signatures of social synchrony},
+  volume	= {699},
+  issn		= {0304-3940},
+  url		= {http://dx.doi.org/10.1016/j.neulet.2019.01.037},
+  doi		= {10.1016/j.neulet.2019.01.037},
+  journal	= {Neuroscience Letters},
+  publisher	= {Elsevier BV},
+  author	= {Fitzpatrick, Paula and Mitchell, Teresa and Schmidt, R.C.
+		  and Kennedy, David and Frazier, Jean A.},
+  year		= {2019},
+  month		= apr,
+  pages		= {24–30}
+}
+
+@Article{	  gan_or_2020,
+  title		= {The Quebec Parkinson Network: A Researcher-Patient
+		  Matching Platform and Multimodal Biorepository},
+  volume	= {10},
+  issn		= {1877-718X},
+  url		= {http://dx.doi.org/10.3233/jpd-191775},
+  doi		= {10.3233/jpd-191775},
+  number	= {1},
+  journal	= {Journal of Parkinson’s Disease},
+  publisher	= {SAGE Publications},
+  author	= {Gan-Or, Ziv and Rao, Trisha and Leveille, Etienne and
+		  Degroot, Clotilde and Chouinard, Sylvain and Cicchetti,
+		  Francesca and Dagher, Alain and Das, Samir and Desautels,
+		  Alex and Drouin-Ouellet, Janelle and Durcan, Thomas and
+		  Gagnon, Jean-François and Genge, Angela and Karamchandani,
+		  Jason and Lafontaine, Anne-Louise and Sun, Sonia Lai Wing
+		  and Langlois, Mélanie and Levesque, Martin and Melmed,
+		  Calvin and Panisset, Michel and Parent, Martin and Poline,
+		  Jean-Baptiste and Postuma, Ronald B. and Pourcher,
+		  Emmanuelle and Rouleau, Guy A. and Sharp, Madeleine and
+		  Monchi, Oury and Dupré, Nicolas and Fon, Edward A.},
+  year		= {2020},
+  month		= jan,
+  pages		= {301–313}
+}
+
+@Article{	  gau_2021,
+  title		= {Brainhack: Developing a culture of open, inclusive,
+		  community-driven neuroscience},
+  volume	= {109},
+  issn		= {0896-6273},
+  url		= {http://dx.doi.org/10.1016/j.neuron.2021.04.001},
+  doi		= {10.1016/j.neuron.2021.04.001},
+  number	= {11},
+  journal	= {Neuron},
+  publisher	= {Elsevier BV},
+  author	= {Gau, Rémi and Noble, Stephanie and Heuer, Katja and
+		  Bottenhorn, Katherine L. and Bilgin, Isil P. and Yang,
+		  Yu-Fang and Huntenburg, Julia M. and Bayer, Johanna M.M.
+		  and Bethlehem, Richard A.I. and Rhoads, Shawn A. and
+		  Vogelbacher, Christoph and Borghesani, Valentina and
+		  Levitis, Elizabeth and Wang, Hao-Ting and Van Den Bossche,
+		  Sofie and Kobeleva, Xenia and Legarreta, Jon Haitz and
+		  Guay, Samuel and Atay, Selim Melvin and Varoquaux, Gael P.
+		  and Huijser, Dorien C. and Sandström, Malin S. and
+		  Herholz, Peer and Nastase, Samuel A. and Badhwar, AmanPreet
+		  and Dumas, Guillaume and Schwab, Simon and Moia, Stefano
+		  and Dayan, Michael and Bassil, Yasmine and Brooks, Paula P.
+		  and Mancini, Matteo and Shine, James M. and O’Connor,
+		  David and Xie, Xihe and Poggiali, Davide and Friedrich,
+		  Patrick and Heinsfeld, Anibal S. and Riedl, Lydia and Toro,
+		  Roberto and Caballero-Gaudes, César and Eklund, Anders and
+		  Garner, Kelly G. and Nolan, Christopher R. and Demeter,
+		  Damion V. and Barrios, Fernando A. and Merchant, Junaid S.
+		  and McDevitt, Elizabeth A. and Oostenveld, Robert and
+		  Craddock, R. Cameron and Rokem, Ariel and Doyle, Andrew and
+		  Ghosh, Satrajit S. and Nikolaidis, Aki and Stanley, Olivia
+		  W. and Uruñuela, Eneko and Anousheh, Nasim and
+		  Arnatkeviciute, Aurina and Auzias, Guillaume and Bachar,
+		  Dipankar and Bannier, Elise and Basanisi, Ruggero and
+		  Basavaraj, Arshitha and Bedini, Marco and Bellec, Pierre
+		  and Benn, R. Austin and Berluti, Kathryn and Bollmann,
+		  Steffen and Bollmann, Saskia and Bradley, Claire and Brown,
+		  Jesse and Buchweitz, Augusto and Callahan, Patrick and
+		  Chan, Micaela Y. and Chandio, Bramsh Q. and Cheng, Theresa
+		  and Chopra, Sidhant and Chung, Ai Wern and Close, Thomas G.
+		  and Combrisson, Etienne and Cona, Giorgia and Constable, R.
+		  Todd and Cury, Claire and Dadi, Kamalaker and Damasceno,
+		  Pablo F. and Das, Samir and De Vico Fallani, Fabrizio and
+		  DeStasio, Krista and Dickie, Erin W. and Dorfschmidt, Lena
+		  and Duff, Eugene P. and DuPre, Elizabeth and Dziura, Sarah
+		  and Esper, Nathalia B. and Esteban, Oscar and Fadnavis,
+		  Shreyas and Flandin, Guillaume and Flannery, Jessica E. and
+		  Flournoy, John and Forkel, Stephanie J. and Franco,
+		  Alexandre R. and Ganesan, Saampras and Gao, Siyuan and
+		  García Alanis, José C. and Garyfallidis, Eleftherios and
+		  Glatard, Tristan and Glerean, Enrico and Gonzalez-Castillo,
+		  Javier and Gould van Praag, Cassandra D. and Greene,
+		  Abigail S. and Gupta, Geetika and Hahn, Catherine Alice and
+		  Halchenko, Yaroslav O. and Handwerker, Daniel and Hartmann,
+		  Thomas S. and Hayot-Sasson, Valérie and Heunis, Stephan
+		  and Hoffstaedter, Felix and Hohmann, Daniela M. and Horien,
+		  Corey and Ioanas, Horea-Ioan and Iordan, Alexandru and
+		  Jiang, Chao and Joseph, Michael and Kai, Jason and
+		  Karakuzu, Agah and Kennedy, David N. and Keshavan, Anisha
+		  and Khan, Ali R. and Kiar, Gregory and Klink, P. Christiaan
+		  and Koppelmans, Vincent and Koudoro, Serge and Laird,
+		  Angela R. and Langs, Georg and Laws, Marissa and Licandro,
+		  Roxane and Liew, Sook-Lei and Lipic, Tomislav and Litinas,
+		  Krisanne and Lurie, Daniel J. and Lussier, Désirée and
+		  Madan, Christopher R. and Mais, Lea-Theresa and Mansour L,
+		  Sina and Manzano-Patron, J.P. and Maoutsa, Dimitra and
+		  Marcon, Matheus and Margulies, Daniel S. and Marinato,
+		  Giorgio and Marinazzo, Daniele and Markiewicz, Christopher
+		  J. and Maumet, Camille and Meneguzzi, Felipe and Meunier,
+		  David and Milham, Michael P. and Mills, Kathryn L. and
+		  Momi, Davide and Moreau, Clara A. and Motala, Aysha and
+		  Moxon-Emre, Iska and Nichols, Thomas E. and Nielson, Dylan
+		  M. and Nilsonne, Gustav and Novello, Lisa and O’Brien,
+		  Caroline and Olafson, Emily and Oliver, Lindsay D. and
+		  Onofrey, John A. and Orchard, Edwina R. and Oudyk, Kendra
+		  and Park, Patrick J. and Parsapoor, Mahboobeh and Pasquini,
+		  Lorenzo and Peltier, Scott and Pernet, Cyril R. and
+		  Pienaar, Rudolph and Pinheiro-Chagas, Pedro and Poline,
+		  Jean-Baptiste and Qiu, Anqi and Quendera, Tiago and Rice,
+		  Laura C. and Rocha-Hidalgo, Joscelin and Rutherford, Saige
+		  and Scharinger, Mathias and Scheinost, Dustin and Shariq,
+		  Deena and Shaw, Thomas B. and Siless, Viviana and
+		  Simmonite, Molly and Sirmpilatze, Nikoloz and Spence, Hayli
+		  and Sprenger, Julia and Stajduhar, Andrija and Szinte,
+		  Martin and Takerkart, Sylvain and Tam, Angela and
+		  Tejavibulya, Link and Thiebaut de Schotten, Michel and
+		  Thome, Ina and Tomaz da Silva, Laura and Traut, Nicolas and
+		  Uddin, Lucina Q. and Vallesi, Antonino and VanMeter, John
+		  W. and Vijayakumar, Nandita and di Oleggio Castello, Matteo
+		  Visconti and Vohryzek, Jakub and Vukojević, Jakša and
+		  Whitaker, Kirstie Jane and Whitmore, Lucy and Wideman,
+		  Steve and Witt, Suzanne T. and Xie, Hua and Xu, Ting and
+		  Yan, Chao-Gan and Yeh, Fang-Cheng and Yeo, B.T. Thomas and
+		  Zuo, Xi-Nian},
+  year		= {2021},
+  month		= jun,
+  pages		= {1769–1775}
+}
+
+@Article{	  ghosh_2017,
+  title		= {A very simple, re-executable neuroimaging publication},
+  volume	= {6},
+  issn		= {2046-1402},
+  url		= {http://dx.doi.org/10.12688/f1000research.10783.2},
+  doi		= {10.12688/f1000research.10783.2},
+  journal	= {F1000Research},
+  publisher	= {F1000 Research Ltd},
+  author	= {Ghosh, Satrajit S. and Poline, Jean-Baptiste and Keator,
+		  David B. and Halchenko, Yaroslav O. and Thomas, Adam G. and
+		  Kessler, Daniel A. and Kennedy, David N.},
+  year		= {2017},
+  month		= jun,
+  pages		= {124}
+}
+
+@Article{	  gorgolewski_2016,
+  title		= {The brain imaging data structure, a format for organizing
+		  and describing outputs of neuroimaging experiments},
+  volume	= {3},
+  issn		= {2052-4463},
+  url		= {http://dx.doi.org/10.1038/sdata.2016.44},
+  doi		= {10.1038/sdata.2016.44},
+  number	= {1},
+  journal	= {Scientific Data},
+  publisher	= {Springer Science and Business Media LLC},
+  author	= {Gorgolewski, Krzysztof J. and Auer, Tibor and Calhoun,
+		  Vince D. and Craddock, R. Cameron and Das, Samir and Duff,
+		  Eugene P. and Flandin, Guillaume and Ghosh, Satrajit S. and
+		  Glatard, Tristan and Halchenko, Yaroslav O. and Handwerker,
+		  Daniel A. and Hanke, Michael and Keator, David and Li,
+		  Xiangrui and Michael, Zachary and Maumet, Camille and
+		  Nichols, B. Nolan and Nichols, Thomas E. and Pellman, John
+		  and Poline, Jean-Baptiste and Rokem, Ariel and Schaefer,
+		  Gunnar and Sochat, Vanessa and Triplett, William and
+		  Turner, Jessica A. and Varoquaux, Gaël and Poldrack,
+		  Russell A.},
+  year		= {2016},
+  month		= jun
+}
+
+@Article{	  gorgolewski_2017,
+  title		= {BIDS apps: Improving ease of use, accessibility, and
+		  reproducibility of neuroimaging data analysis methods},
+  volume	= {13},
+  issn		= {1553-7358},
+  url		= {http://dx.doi.org/10.1371/journal.pcbi.1005209},
+  doi		= {10.1371/journal.pcbi.1005209},
+  number	= {3},
+  journal	= {PLOS Computational Biology},
+  publisher	= {Public Library of Science (PLoS)},
+  author	= {Gorgolewski, Krzysztof J. and Alfaro-Almagro, Fidel and
+		  Auer, Tibor and Bellec, Pierre and Capotă, Mihai and
+		  Chakravarty, M. Mallar and Churchill, Nathan W. and Cohen,
+		  Alexander Li and Craddock, R. Cameron and Devenyi, Gabriel
+		  A. and Eklund, Anders and Esteban, Oscar and Flandin,
+		  Guillaume and Ghosh, Satrajit S. and Guntupalli, J. Swaroop
+		  and Jenkinson, Mark and Keshavan, Anisha and Kiar, Gregory
+		  and Liem, Franziskus and Raamana, Pradeep Reddy and
+		  Raffelt, David and Steele, Christopher J. and Quirion,
+		  Pierre-Olivier and Smith, Robert E. and Strother, Stephen
+		  C. and Varoquaux, Gaël and Wang, Yida and Yarkoni, Tal and
+		  Poldrack, Russell A.},
+  editor	= {Schneidman, Dina},
+  year		= {2017},
+  month		= mar,
+  pages		= {e1005209}
+}
+
+@Article{	  guell_2018,
+  title		= {Functional gradients of the cerebellum},
+  volume	= {7},
+  issn		= {2050-084X},
+  url		= {http://dx.doi.org/10.7554/elife.36652},
+  doi		= {10.7554/elife.36652},
+  journal	= {eLife},
+  publisher	= {eLife Sciences Publications, Ltd},
+  author	= {Guell, Xavier and Schmahmann, Jeremy D and Gabrieli, John
+		  DE and Ghosh, Satrajit S},
+  year		= {2018},
+  month		= aug
+}
+
+@Article{	  guell_2019,
+  title		= {LittleBrain: A gradient-based tool for the topographical
+		  interpretation of cerebellar neuroimaging findings},
+  volume	= {14},
+  issn		= {1932-6203},
+  url		= {http://dx.doi.org/10.1371/journal.pone.0210028},
+  doi		= {10.1371/journal.pone.0210028},
+  number	= {1},
+  journal	= {PLOS ONE},
+  publisher	= {Public Library of Science (PLoS)},
+  author	= {Guell, Xavier and Goncalves, Mathias and Kaczmarzyk, Jakub
+		  R. and Gabrieli, John D. E. and Schmahmann, Jeremy D. and
+		  Ghosh, Satrajit S.},
+  editor	= {Margulies, Daniel S.},
+  year		= {2019},
+  month		= jan,
+  pages		= {e0210028}
+}
+
+@Article{	  hagler_2019,
+  title		= {Image processing and analysis methods for the Adolescent
+		  Brain Cognitive Development Study},
+  volume	= {202},
+  issn		= {1053-8119},
+  url		= {http://dx.doi.org/10.1016/j.neuroimage.2019.116091},
+  doi		= {10.1016/j.neuroimage.2019.116091},
+  journal	= {NeuroImage},
+  publisher	= {Elsevier BV},
+  author	= {Hagler, Donald J. and Hatton, SeanN. and Cornejo, M.
+		  Daniela and Makowski, Carolina and Fair, Damien A. and
+		  Dick, Anthony Steven and Sutherland, Matthew T. and Casey,
+		  B.J. and Barch, Deanna M. and Harms, Michael P. and Watts,
+		  Richard and Bjork, James M. and Garavan, Hugh P. and
+		  Hilmer, Laura and Pung, Christopher J. and Sicat, Chelsea
+		  S. and Kuperman, Joshua and Bartsch, Hauke and Xue, Feng
+		  and Heitzeg, Mary M. and Laird, Angela R. and Trinh, Thanh
+		  T. and Gonzalez, Raul and Tapert, Susan F. and Riedel,
+		  Michael C. and Squeglia, Lindsay M. and Hyde, Luke W. and
+		  Rosenberg, Monica D. and Earl, Eric A. and Howlett, Katia
+		  D. and Baker, Fiona C. and Soules, Mary and Diaz, Jazmin
+		  and de Leon, Octavio Ruiz and Thompson, Wesley K. and
+		  Neale, Michael C. and Herting, Megan and Sowell, Elizabeth
+		  R. and Alvarez, Ruben P. and Hawes, Samuel W. and Sanchez,
+		  Mariana and Bodurka, Jerzy and Breslin, Florence J. and
+		  Morris, Amanda Sheffield and Paulus, Martin P. and Simmons,
+		  W. Kyle and Polimeni, Jonathan R. and van der Kouwe, Andre
+		  and Nencka, Andrew S. and Gray, Kevin M. and Pierpaoli,
+		  Carlo and Matochik, John A. and Noronha, Antonio and Aklin,
+		  Will M. and Conway, Kevin and Glantz, Meyer and Hoffman,
+		  Elizabeth and Little, Roger and Lopez, Marsha and
+		  Pariyadath, Vani and Weiss, Susan RB. and Wolff-Hughes,
+		  Dana L. and DelCarmen-Wiggins, Rebecca and Feldstein Ewing,
+		  Sarah W. and Miranda-Dominguez, Oscar and Nagel, Bonnie J.
+		  and Perrone, Anders J. and Sturgeon, Darrick T. and
+		  Goldstone, Aimee and Pfefferbaum, Adolf and Pohl, Kilian M.
+		  and Prouty, Devin and Uban, Kristina and Bookheimer, Susan
+		  Y. and Dapretto, Mirella and Galvan, Adriana and Bagot,
+		  Kara and Giedd, Jay and Infante, M. Alejandra and Jacobus,
+		  Joanna and Patrick, Kevin and Shilling, Paul D. and
+		  Desikan, Rahul and Li, Yi and Sugrue, Leo and Banich, Marie
+		  T. and Friedman, Naomi and Hewitt, John K. and Hopfer,
+		  Christian and Sakai, Joseph and Tanabe, Jody and Cottler,
+		  Linda B. and Nixon, Sara Jo and Chang, Linda and Cloak,
+		  Christine and Ernst, Thomas and Reeves, Gloria and Kennedy,
+		  David N. and Heeringa, Steve and Peltier, Scott and
+		  Schulenberg, John and Sripada, Chandra and Zucker, Robert
+		  A. and Iacono, William G. and Luciana, Monica and Calabro,
+		  Finnegan J. and Clark, Duncan B. and Lewis, David A. and
+		  Luna, Beatriz and Schirda, Claudiu and Brima, Tufikameni
+		  and Foxe, John J. and Freedman, Edward G. and Mruzek,
+		  Daniel W. and Mason, Michael J. and Huber, Rebekah and
+		  McGlade, Erin and Prescot, Andrew and Renshaw, Perry F. and
+		  Yurgelun-Todd, Deborah A. and Allgaier, Nicholas A. and
+		  Dumas, Julie A. and Ivanova, Masha and Potter, Alexandra
+		  and Florsheim, Paul and Larson, Christine and Lisdahl,
+		  Krista and Charness, Michael E. and Fuemmeler, Bernard and
+		  Hettema, John M. and Maes, Hermine H. and Steinberg, Joel
+		  and Anokhin, Andrey P. and Glaser, Paul and Heath, Andrew
+		  C. and Madden, Pamela A. and Baskin-Sommers, Arielle and
+		  Constable, R. Todd and Grant, Steven J. and Dowling,
+		  Gayathri J. and Brown, Sandra A. and Jernigan, Terry L. and
+		  Dale, Anders M.},
+  year		= {2019},
+  month		= nov,
+  pages		= {116091}
+}
+
+@Article{	  halchenko_2021,
+  title		= {DataLad: distributed system for joint management of code,
+		  data, and their relationship},
+  volume	= {6},
+  issn		= {2475-9066},
+  url		= {http://dx.doi.org/10.21105/joss.03262},
+  doi		= {10.21105/joss.03262},
+  number	= {63},
+  journal	= {Journal of Open Source Software},
+  publisher	= {The Open Journal},
+  author	= {Halchenko, Yaroslav and Meyer, Kyle and Poldrack, Benjamin
+		  and Solanky, Debanjum and Wagner, Adina and Gors, Jason and
+		  MacFarlane, Dave and Pustina, Dorian and Sochat, Vanessa
+		  and Ghosh, Satrajit and Mönch, Christian and Markiewicz,
+		  Christopher and Waite, Laura and Shlyakhter, Ilya and de la
+		  Vega, Alejandro and Hayashi, Soichi and Häusler, Christian
+		  and Poline, Jean-Baptiste and Kadelka, Tobias and Skytén,
+		  Kusti and Jarecka, Dorota and Kennedy, David and Strauss,
+		  Ted and Cieslak, Matt and Vavra, Peter and Ioanas,
+		  Horea-Ioan and Schneider, Robin and Pflüger, Mika and
+		  Haxby, James and Eickhoff, Simon and Hanke, Michael},
+  year		= {2021},
+  month		= jul,
+  pages		= {3262}
+}
+
+@Article{	  halchenko_2024,
+  title		= {HeuDiConv — flexible DICOM conversion into structured
+		  directory layouts},
+  volume	= {9},
+  issn		= {2475-9066},
+  url		= {http://dx.doi.org/10.21105/joss.05839},
+  doi		= {10.21105/joss.05839},
+  number	= {99},
+  journal	= {Journal of Open Source Software},
+  publisher	= {The Open Journal},
+  author	= {Halchenko, Yaroslav O. and Goncalves, Mathias and Ghosh,
+		  Satrajit and Velasco, Pablo and Visconti di Oleggio
+		  Castello, Matteo and Salo, Taylor and Wodder, John T. and
+		  Hanke, Michael and Sadil, Patrick and Gorgolewski,
+		  Krzysztof Jacek and Ioanas, Horea-Ioan and Rorden, Chris
+		  and Hendrickson, Timothy J. and Dayan, Michael and
+		  Houlihan, Sean Dae and Kent, James and Strauss, Ted and
+		  Lee, John and To, Isaac and Markiewicz, Christopher J. and
+		  Lukas, Darren and Butler, Ellyn R. and Thompson, Todd and
+		  Termenon, Maite and Smith, David V. and Macdonald, Austin
+		  and Kennedy, David N.},
+  year		= {2024},
+  month		= jul,
+  pages		= {5839}
+}
+
+@Article{	  hanke_2021,
+  title		= {In defense of decentralized research data management},
+  volume	= {0},
+  issn		= {0947-0875},
+  url		= {http://dx.doi.org/10.1515/nf-2020-0037},
+  doi		= {10.1515/nf-2020-0037},
+  number	= {0},
+  journal	= {Neuroforum},
+  publisher	= {Walter de Gruyter GmbH},
+  author	= {Hanke, Michael and Pestilli, Franco and Wagner, Adina S.
+		  and Markiewicz, Christopher J. and Poline, Jean-Baptiste
+		  and Halchenko, Yaroslav O.},
+  year		= {2021},
+  month		= jan
+}
+
+@Article{	  hodge_2021,
+  title		= {An assessment of the autism neuroimaging literature for
+		  the prospects of re-executability},
+  volume	= {9},
+  issn		= {2046-1402},
+  url		= {http://dx.doi.org/10.12688/f1000research.25306.2},
+  doi		= {10.12688/f1000research.25306.2},
+  journal	= {F1000Research},
+  publisher	= {F1000 Research Ltd},
+  author	= {Hodge, Steven M. and Haselgrove, Christian and Honor, Leah
+		  and Kennedy, David N. and Frazier, Jean A.},
+  year		= {2021},
+  month		= mar,
+  pages		= {1031}
+}
+
+@Article{	  honor_2016,
+  title		= {Data Citation in Neuroimaging: Proposed Best Practices for
+		  Data Identification and Attribution},
+  volume	= {10},
+  issn		= {1662-5196},
+  url		= {http://dx.doi.org/10.3389/fninf.2016.00034},
+  doi		= {10.3389/fninf.2016.00034},
+  journal	= {Frontiers in Neuroinformatics},
+  publisher	= {Frontiers Media SA},
+  author	= {Honor, Leah B. and Haselgrove, Christian and Frazier, Jean
+		  A. and Kennedy, David N.},
+  year		= {2016},
+  month		= aug
+}
+
+@Article{	  hubbard_2020,
+  title		= {Brain function and clinical characterization in the Boston
+		  adolescent neuroimaging of depression and anxiety study},
+  volume	= {27},
+  issn		= {2213-1582},
+  url		= {http://dx.doi.org/10.1016/j.nicl.2020.102240},
+  doi		= {10.1016/j.nicl.2020.102240},
+  journal	= {NeuroImage: Clinical},
+  publisher	= {Elsevier BV},
+  author	= {Hubbard, N.A. and Siless, V. and Frosch, I.R. and
+		  Goncalves, M. and Lo, N. and Wang, J. and Bauer, C.C.C. and
+		  Conroy, K. and Cosby, E. and Hay, A. and Jones, R. and
+		  Pinaire, M. and Vaz De Souza, F. and Vergara, G. and Ghosh,
+		  S. and Henin, A. and Hirshfeld-Becker, D.R. and Hofmann,
+		  S.G. and Rosso, I.M. and Auerbach, R.P. and Pizzagalli,
+		  D.A. and Yendiki, A. and Gabrieli, J.D.E. and
+		  Whitfield-Gabrieli, S.},
+  year		= {2020},
+  pages		= {102240}
+}
+
+@Article{	  hubbard_2024,
+  title		= {The Human Connectome Project of adolescent anxiety and
+		  depression dataset},
+  volume	= {11},
+  issn		= {2052-4463},
+  url		= {http://dx.doi.org/10.1038/s41597-024-03629-x},
+  doi		= {10.1038/s41597-024-03629-x},
+  number	= {1},
+  journal	= {Scientific Data},
+  publisher	= {Springer Science and Business Media LLC},
+  author	= {Hubbard, N. A. and Bauer, C. C. C. and Siless, V. and
+		  Auerbach, R. P. and Elam, J. S. and Frosch, I. R. and
+		  Henin, A. and Hofmann, S. G. and Hodge, M. R. and Jones, R.
+		  and Lenzini, P. and Lo, N. and Park, A. T. and Pizzagalli,
+		  D. A. and Vaz-DeSouza, F. and Gabrieli, J. D. E. and
+		  Whitfield-Gabrieli, S. and Yendiki, A. and Ghosh, S. S.},
+  year		= {2024},
+  month		= aug
+}
+
+@Article{	  hung_2020,
+  title		= {Cingulum-Callosal white-matter microstructure associated
+		  with emotional dysregulation in children: A diffusion
+		  tensor imaging study},
+  volume	= {27},
+  issn		= {2213-1582},
+  url		= {http://dx.doi.org/10.1016/j.nicl.2020.102266},
+  doi		= {10.1016/j.nicl.2020.102266},
+  journal	= {NeuroImage: Clinical},
+  publisher	= {Elsevier BV},
+  author	= {Hung, Yuwen and Uchida, Mai and Gaillard, Schuyler L. and
+		  Woodworth, Hilary and Kelberman, Caroline and Capella,
+		  James and Kadlec, Kelly and Goncalves, Mathias and Ghosh,
+		  Satrajit and Yendiki, Anastasia and Chai, Xiaoqian J. and
+		  Hirshfeld-Becker, Dina R. and Whitfield-Gabrieli, Susan and
+		  Gabrieli, John D.E. and Biederman, Joseph},
+  year		= {2020},
+  pages		= {102266}
+}
+
+@Article{	  huntenburg_2017,
+  title		= {A Systematic Relationship Between Functional Connectivity
+		  and Intracortical Myelin in the Human Cerebral Cortex},
+  volume	= {27},
+  issn		= {1460-2199},
+  url		= {http://dx.doi.org/10.1093/cercor/bhx030},
+  doi		= {10.1093/cercor/bhx030},
+  number	= {2},
+  journal	= {Cerebral Cortex},
+  publisher	= {Oxford University Press (OUP)},
+  author	= {Huntenburg, Julia M. and Bazin, Pierre-Louis and Goulas,
+		  Alexandros and Tardif, Christine L. and Villringer, Arno
+		  and Margulies, Daniel S.},
+  year		= {2017},
+  month		= feb,
+  pages		= {981–997}
+}
+
+@Article{	  ioanas_2024,
+  title		= {Neuroimaging article reexecution and reproduction
+		  assessment system},
+  volume	= {18},
+  issn		= {1662-5196},
+  url		= {http://dx.doi.org/10.3389/fninf.2024.1376022},
+  doi		= {10.3389/fninf.2024.1376022},
+  journal	= {Frontiers in Neuroinformatics},
+  publisher	= {Frontiers Media SA},
+  author	= {Ioanas, Horea-Ioan and Macdonald, Austin and Halchenko,
+		  Yaroslav O.},
+  year		= {2024},
+  month		= jul
+}
+
+@Article{	  irimia_2017,
+  title		= {Mobile Monitoring of Traumatic Brain Injury in Older
+		  Adults: Challenges and Opportunities},
+  volume	= {15},
+  issn		= {1559-0089},
+  url		= {http://dx.doi.org/10.1007/s12021-017-9335-z},
+  doi		= {10.1007/s12021-017-9335-z},
+  number	= {3},
+  journal	= {Neuroinformatics},
+  publisher	= {Springer Science and Business Media LLC},
+  author	= {Irimia, Andrei and Wei, Susan and Lu, Nanshu and Moore,
+		  Constance M. and Kennedy, David N.},
+  year		= {2017},
+  month		= jul,
+  pages		= {227–230}
+}
+
+@Article{	  james_2016,
+  title		= {Rhythmic Interlimb Coordination Impairments and the Risk
+		  for Developing Mobility Limitations},
+  issn		= {1758-535X},
+  url		= {http://dx.doi.org/10.1093/gerona/glw236},
+  doi		= {10.1093/gerona/glw236},
+  journal	= {The Journals of Gerontology Series A: Biological Sciences
+		  and Medical Sciences},
+  publisher	= {Oxford University Press (OUP)},
+  author	= {James, Eric G. and Leveille, Suzanne G. and Hausdorff,
+		  Jeffrey M. and Travison, Thomas and Kennedy, David N. and
+		  Tucker, Katherine L. and Al Snih, Soham and Markides,
+		  Kyriakos S. and Bean, Jonathan F.},
+  year		= {2016},
+  month		= dec,
+  pages		= {glw236}
+}
+
+@Article{	  kennedy_2017,
+  title		= {The Information Sharing Statement Grows Some Teeth},
+  volume	= {15},
+  issn		= {1559-0089},
+  url		= {http://dx.doi.org/10.1007/s12021-017-9331-3},
+  doi		= {10.1007/s12021-017-9331-3},
+  number	= {2},
+  journal	= {Neuroinformatics},
+  publisher	= {Springer Science and Business Media LLC},
+  author	= {Kennedy, David N.},
+  year		= {2017},
+  month		= apr,
+  pages		= {113–114}
+}
+
+@Article{	  kennedy_2018,
+  title		= {Neuroimaging Neuroinformatics: Sample Size and Other
+		  Evolutionary Topics},
+  volume	= {16},
+  issn		= {1559-0089},
+  url		= {http://dx.doi.org/10.1007/s12021-018-9379-8},
+  doi		= {10.1007/s12021-018-9379-8},
+  number	= {2},
+  journal	= {Neuroinformatics},
+  publisher	= {Springer Science and Business Media LLC},
+  author	= {Kennedy, David N.},
+  year		= {2018},
+  month		= apr,
+  pages		= {149–150}
+}
+
+@Article{	  kennedy_2019,
+  title		= {Everything Matters: The ReproNim Perspective on
+		  Reproducible Neuroimaging},
+  volume	= {13},
+  issn		= {1662-5196},
+  url		= {http://dx.doi.org/10.3389/fninf.2019.00001},
+  doi		= {10.3389/fninf.2019.00001},
+  journal	= {Frontiers in Neuroinformatics},
+  publisher	= {Frontiers Media SA},
+  author	= {Kennedy, David N. and Abraham, Sanu A. and Bates, Julianna
+		  F. and Crowley, Albert and Ghosh, Satrajit and Gillespie,
+		  Tom and Goncalves, Mathias and Grethe, Jeffrey S. and
+		  Halchenko, Yaroslav O. and Hanke, Michael and Haselgrove,
+		  Christian and Hodge, Steven M. and Jarecka, Dorota and
+		  Kaczmarzyk, Jakub and Keator, David B. and Meyer, Kyle and
+		  Martone, Maryann E. and Padhy, Smruti and Poline,
+		  Jean-Baptiste and Preuss, Nina and Sincomb, Troy and
+		  Travers, Matt},
+  year		= {2019},
+  month		= feb
+}
+
+@Article{	  keshavan_2019,
+  title		= {From the Wet Lab to the Web Lab: A Paradigm Shift in Brain
+		  Imaging Research},
+  volume	= {13},
+  issn		= {1662-5196},
+  url		= {http://dx.doi.org/10.3389/fninf.2019.00003},
+  doi		= {10.3389/fninf.2019.00003},
+  journal	= {Frontiers in Neuroinformatics},
+  publisher	= {Frontiers Media SA},
+  author	= {Keshavan, Anisha and Poline, Jean-Baptiste},
+  year		= {2019},
+  month		= mar
+}
+
+@Article{	  kiar_2023,
+  title		= {Align with the NMIND consortium for better neuroimaging},
+  volume	= {7},
+  issn		= {2397-3374},
+  url		= {http://dx.doi.org/10.1038/s41562-023-01647-0},
+  doi		= {10.1038/s41562-023-01647-0},
+  number	= {7},
+  journal	= {Nature Human Behaviour},
+  publisher	= {Springer Science and Business Media LLC},
+  author	= {Kiar, Gregory and Clucas, Jon and Feczko, Eric and
+		  Goncalves, Mathias and Jarecka, Dorota and Markiewicz,
+		  Christopher J. and Halchenko, Yaroslav O. and Hermosillo,
+		  Robert and Li, Xinhui and Miranda-Dominguez, Oscar and
+		  Ghosh, Satrajit and Poldrack, Russell A. and Satterthwaite,
+		  Theodore D. and Milham, Michael P. and Fair, Damien},
+  year		= {2023},
+  month		= jun,
+  pages		= {1027–1028}
+}
+
+@Article{	  kim_2018,
+  title		= {Experimenting with reproducibility: a case study of
+		  robustness in bioinformatics},
+  volume	= {7},
+  issn		= {2047-217X},
+  url		= {http://dx.doi.org/10.1093/gigascience/giy077},
+  doi		= {10.1093/gigascience/giy077},
+  number	= {7},
+  journal	= {GigaScience},
+  publisher	= {Oxford University Press (OUP)},
+  author	= {Kim, Yang-Min and Poline, Jean-Baptiste and Dumas,
+		  Guillaume},
+  year		= {2018},
+  month		= jun
+}
+
+@Article{	  klein_2017,
+  title		= {Mindboggling morphometry of human brains},
+  volume	= {13},
+  issn		= {1553-7358},
+  url		= {http://dx.doi.org/10.1371/journal.pcbi.1005350},
+  doi		= {10.1371/journal.pcbi.1005350},
+  number	= {2},
+  journal	= {PLOS Computational Biology},
+  publisher	= {Public Library of Science (PLoS)},
+  author	= {Klein, Arno and Ghosh, Satrajit S. and Bao, Forrest S. and
+		  Giard, Joachim and Häme, Yrjö and Stavsky, Eliezer and
+		  Lee, Noah and Rossa, Brian and Reuter, Martin and Chaibub
+		  Neto, Elias and Keshavan, Anisha},
+  editor	= {Schneidman, Dina},
+  year		= {2017},
+  month		= feb,
+  pages		= {e1005350}
+}
+
+@Article{	  klein_2021,
+  title		= {Remote Digital Psychiatry for Mobile Mental Health
+		  Assessment and Therapy: MindLogger Platform Development
+		  Study},
+  volume	= {23},
+  issn		= {1438-8871},
+  url		= {http://dx.doi.org/10.2196/22369},
+  doi		= {10.2196/22369},
+  number	= {11},
+  journal	= {Journal of Medical Internet Research},
+  publisher	= {JMIR Publications Inc.},
+  author	= {Klein, Arno and Clucas, Jon and Krishnakumar, Anirudh and
+		  Ghosh, Satrajit S and Van Auken, Wilhelm and Thonet,
+		  Benjamin and Sabram, Ihor and Acuna, Nino and Keshavan,
+		  Anisha and Rossiter, Henry and Xiao, Yao and Semenuta,
+		  Sergey and Badioli, Alessandra and Konishcheva, Kseniia and
+		  Abraham, Sanu Ann and Alexander, Lindsay M and Merikangas,
+		  Kathleen R and Swendsen, Joel and Lindner, Ariel B and
+		  Milham, Michael P},
+  year		= {2021},
+  month		= nov,
+  pages		= {e22369}
+}
+
+@Article{	  kumar_2022,
+  title		= {The Neuroimaging Data Model Linear Regression Tool
+		  (nidm_linreg): PyNIDM Project},
+  volume	= {11},
+  issn		= {2046-1402},
+  url		= {http://dx.doi.org/10.12688/f1000research.108008.2},
+  doi		= {10.12688/f1000research.108008.2},
+  journal	= {F1000Research},
+  publisher	= {F1000 Research Ltd},
+  author	= {Kumar, Ashmita and Crowley, Albert and Queder, Nazek and
+		  Poline, JB and Ghosh, Satrajit S. and Kennedy, David and
+		  Grethe, Jeffrey S. and Helmer, Karl G. and Keator, David
+		  B.},
+  year		= {2022},
+  month		= jul,
+  pages		= {228}
+}
+
+@Article{	  larivi_re_2023,
+  title		= {BrainStat: A toolbox for brain-wide statistics and
+		  multimodal feature associations},
+  volume	= {266},
+  issn		= {1053-8119},
+  url		= {http://dx.doi.org/10.1016/j.neuroimage.2022.119807},
+  doi		= {10.1016/j.neuroimage.2022.119807},
+  journal	= {NeuroImage},
+  publisher	= {Elsevier BV},
+  author	= {Larivière, Sara and Bayrak, Şeyma and Vos de Wael,
+		  Reinder and Benkarim, Oualid and Herholz, Peer and
+		  Rodriguez-Cruces, Raul and Paquola, Casey and Hong,
+		  Seok-Jun and Misic, Bratislav and Evans, Alan C. and Valk,
+		  Sofie L. and Bernhardt, Boris C.},
+  year		= {2023},
+  month		= feb,
+  pages		= {119807}
+}
+
+@Article{	  lin_2020,
+  title		= {The TRUST Principles for digital repositories},
+  volume	= {7},
+  issn		= {2052-4463},
+  url		= {http://dx.doi.org/10.1038/s41597-020-0486-7},
+  doi		= {10.1038/s41597-020-0486-7},
+  number	= {1},
+  journal	= {Scientific Data},
+  publisher	= {Springer Science and Business Media LLC},
+  author	= {Lin, Dawei and Crabtree, Jonathan and Dillo, Ingrid and
+		  Downs, Robert R. and Edmunds, Rorie and Giaretta, David and
+		  De Giusti, Marisa and L’Hours, Hervé and Hugo, Wim and
+		  Jenkyns, Reyna and Khodiyar, Varsha and Martone, Maryann E.
+		  and Mokrane, Mustapha and Navale, Vivek and Petters,
+		  Jonathan and Sierman, Barbara and Sokolova, Dina V. and
+		  Stockhause, Martina and Westbrook, John},
+  year		= {2020},
+  month		= may
+}
+
+@Article{	  lin_2024,
+  title		= {Transforming modeling in neurorehabilitation: clinical
+		  insights for personalized rehabilitation},
+  volume	= {21},
+  issn		= {1743-0003},
+  url		= {http://dx.doi.org/10.1186/s12984-024-01309-w},
+  doi		= {10.1186/s12984-024-01309-w},
+  number	= {1},
+  journal	= {Journal of NeuroEngineering and Rehabilitation},
+  publisher	= {Springer Science and Business Media LLC},
+  author	= {Lin, David J. and Backus, Deborah and Chakraborty, Stuti
+		  and Liew, Sook-Lei and Valero-Cuevas, Francisco J. and
+		  Patten, Carolynn and Cotton, R James},
+  year		= {2024},
+  month		= feb
+}
+
+@Article{	  lo_2023,
+  title		= {A standardized protocol for manually segmenting stroke
+		  lesions on high-resolution T1-weighted MR images},
+  volume	= {1},
+  issn		= {2813-1193},
+  url		= {http://dx.doi.org/10.3389/fnimg.2022.1098604},
+  doi		= {10.3389/fnimg.2022.1098604},
+  journal	= {Frontiers in Neuroimaging},
+  publisher	= {Frontiers Media SA},
+  author	= {Lo, Bethany P. and Donnelly, Miranda R. and Barisano,
+		  Giuseppe and Liew, Sook-Lei},
+  year		= {2023},
+  month		= jan
+}
+
+@Article{	  low_2020,
+  title		= {Identifying bias in models that detect vocal fold
+		  paralysis from audio recordings using explainable machine
+		  learning and clinician ratings},
+  url		= {http://dx.doi.org/10.1101/2020.11.23.20235945},
+  doi		= {10.1101/2020.11.23.20235945},
+  publisher	= {Cold Spring Harbor Laboratory},
+  author	= {Low, Daniel M. and Rao, Vishwanatha and Randolph, Gregory
+		  and Song, Phillip C. and Ghosh, Satrajit S.},
+  year		= {2020},
+  month		= nov
+}
+
+@Article{	  low_2020,
+  title		= {Automated assessment of psychiatric disorders using
+		  speech: A systematic review},
+  volume	= {5},
+  issn		= {2378-8038},
+  url		= {http://dx.doi.org/10.1002/lio2.354},
+  doi		= {10.1002/lio2.354},
+  number	= {1},
+  journal	= {Laryngoscope Investigative Otolaryngology},
+  publisher	= {Wiley},
+  author	= {Low, Daniel M. and Bentley, Kate H. and Ghosh, Satrajit
+		  S.},
+  year		= {2020},
+  month		= jan,
+  pages		= {96–116}
+}
+
+@Article{	  low_2024,
+  title		= {Identifying bias in models that detect vocal fold
+		  paralysis from audio recordings using explainable machine
+		  learning and clinician ratings},
+  volume	= {3},
+  issn		= {2767-3170},
+  url		= {http://dx.doi.org/10.1371/journal.pdig.0000516},
+  doi		= {10.1371/journal.pdig.0000516},
+  number	= {5},
+  journal	= {PLOS Digital Health},
+  publisher	= {Public Library of Science (PLoS)},
+  author	= {Low, Daniel M. and Rao, Vishwanatha and Randolph, Gregory
+		  and Song, Phillip C. and Ghosh, Satrajit S.},
+  editor	= {Li-Jessen, Nicole Yee-Key},
+  year		= {2024},
+  month		= may,
+  pages		= {e0000516}
+}
+
+@Article{	  makris_2023,
+  title		= {A Proposed Human Structural Brain Connectivity Matrix in
+		  the Center for Morphometric Analysis Harvard-Oxford Atlas
+		  Framework: A Historical Perspective and Future Direction
+		  for Enhancing the Precision of Human Structural
+		  Connectivity with a Novel Neuroanatomical Typology},
+  volume	= {45},
+  issn		= {1421-9859},
+  url		= {http://dx.doi.org/10.1159/000530358},
+  doi		= {10.1159/000530358},
+  number	= {4},
+  journal	= {Developmental Neuroscience},
+  publisher	= {S. Karger AG},
+  author	= {Makris, Nikos and Rushmore, Richard and Kaiser, Jonathan
+		  and Albaugh, Matthew and Kubicki, Marek and Rathi, Yogesh
+		  and Zhang, Fan and O’Donnell, Lauren J. and Yeterian,
+		  Edward and Caviness, Verne S. and Kennedy, David N.},
+  year		= {2023},
+  pages		= {161–180}
+}
+
+@Article{	  manelis_2021,
+  title		= {White matter abnormalities in adults with bipolar disorder
+		  type-II and unipolar depression},
+  volume	= {11},
+  issn		= {2045-2322},
+  url		= {http://dx.doi.org/10.1038/s41598-021-87069-2},
+  doi		= {10.1038/s41598-021-87069-2},
+  number	= {1},
+  journal	= {Scientific Reports},
+  publisher	= {Springer Science and Business Media LLC},
+  author	= {Manelis, Anna and Soehner, Adriane and Halchenko, Yaroslav
+		  O. and Satz, Skye and Ragozzino, Rachel and Lucero, Mora
+		  and Swartz, Holly A. and Phillips, Mary L. and Versace,
+		  Amelia},
+  year		= {2021},
+  month		= apr
+}
+
+@Article{	  manelis_2022,
+  title		= {Working memory updating in individuals with bipolar and
+		  unipolar depression: fMRI study},
+  volume	= {12},
+  issn		= {2158-3188},
+  url		= {http://dx.doi.org/10.1038/s41398-022-02211-6},
+  doi		= {10.1038/s41398-022-02211-6},
+  number	= {1},
+  journal	= {Translational Psychiatry},
+  publisher	= {Springer Science and Business Media LLC},
+  author	= {Manelis, Anna and Halchenko, Yaroslav O. and Bonar, Lisa
+		  and Stiffler, Richelle S. and Satz, Skye and Miceli, Rachel
+		  and Ladouceur, Cecile D. and Bebko, Genna and Iyengar,
+		  Satish and Swartz, Holly A. and Phillips, Mary L.},
+  year		= {2022},
+  month		= oct
+}
+
+@Article{	  margulies_2016,
+  title		= {Situating the default-mode network along a principal
+		  gradient of macroscale cortical organization},
+  volume	= {113},
+  issn		= {1091-6490},
+  url		= {http://dx.doi.org/10.1073/pnas.1608282113},
+  doi		= {10.1073/pnas.1608282113},
+  number	= {44},
+  journal	= {Proceedings of the National Academy of Sciences},
+  publisher	= {Proceedings of the National Academy of Sciences},
+  author	= {Margulies, Daniel S. and Ghosh, Satrajit S. and Goulas,
+		  Alexandros and Falkiewicz, Marcel and Huntenburg, Julia M.
+		  and Langs, Georg and Bezgin, Gleb and Eickhoff, Simon B.
+		  and Castellanos, F. Xavier and Petrides, Michael and
+		  Jefferies, Elizabeth and Smallwood, Jonathan},
+  year		= {2016},
+  month		= oct,
+  pages		= {12574–12579}
+}
+
+@Article{	  markello_2021,
+  title		= {Standardizing workflows in imaging transcriptomics with
+		  the abagen toolbox},
+  volume	= {10},
+  issn		= {2050-084X},
+  url		= {http://dx.doi.org/10.7554/elife.72129},
+  doi		= {10.7554/elife.72129},
+  journal	= {eLife},
+  publisher	= {eLife Sciences Publications, Ltd},
+  author	= {Markello, Ross D and Arnatkeviciute, Aurina and Poline,
+		  Jean-Baptiste and Fulcher, Ben D and Fornito, Alex and
+		  Misic, Bratislav},
+  year		= {2021},
+  month		= nov
+}
+
+@Article{	  markiewicz_2021,
+  title		= {The OpenNeuro resource for sharing of neuroscience data},
+  volume	= {10},
+  issn		= {2050-084X},
+  url		= {http://dx.doi.org/10.7554/elife.71774},
+  doi		= {10.7554/elife.71774},
+  journal	= {eLife},
+  publisher	= {eLife Sciences Publications, Ltd},
+  author	= {Markiewicz, Christopher J and Gorgolewski, Krzysztof J and
+		  Feingold, Franklin and Blair, Ross and Halchenko, Yaroslav
+		  O and Miller, Eric and Hardcastle, Nell and Wexler, Joe and
+		  Esteban, Oscar and Goncavles, Mathias and Jwa, Anita and
+		  Poldrack, Russell},
+  year		= {2021},
+  month		= oct
+}
+
+@Article{	  maumet_2016,
+  title		= {Sharing brain mapping statistical results with the
+		  neuroimaging data model},
+  volume	= {3},
+  issn		= {2052-4463},
+  url		= {http://dx.doi.org/10.1038/sdata.2016.102},
+  doi		= {10.1038/sdata.2016.102},
+  number	= {1},
+  journal	= {Scientific Data},
+  publisher	= {Springer Science and Business Media LLC},
+  author	= {Maumet, Camille and Auer, Tibor and Bowring, Alexander and
+		  Chen, Gang and Das, Samir and Flandin, Guillaume and Ghosh,
+		  Satrajit and Glatard, Tristan and Gorgolewski, Krzysztof J.
+		  and Helmer, Karl G. and Jenkinson, Mark and Keator, David
+		  B. and Nichols, B. Nolan and Poline, Jean-Baptiste and
+		  Reynolds, Richard and Sochat, Vanessa and Turner, Jessica
+		  and Nichols, Thomas E.},
+  year		= {2016},
+  month		= dec
+}
+
+@Article{	  mcavoy_2021,
+  title		= {Classification of glioblastoma versus primary central
+		  nervous system lymphoma using convolutional neural
+		  networks},
+  volume	= {11},
+  issn		= {2045-2322},
+  url		= {http://dx.doi.org/10.1038/s41598-021-94733-0},
+  doi		= {10.1038/s41598-021-94733-0},
+  number	= {1},
+  journal	= {Scientific Reports},
+  publisher	= {Springer Science and Business Media LLC},
+  author	= {McAvoy, Malia and Prieto, Paola Calvachi and Kaczmarzyk,
+		  Jakub R. and Fernández, Iván Sánchez and McNulty, Jack
+		  and Smith, Timothy and Yu, Kun-Hsing and Gormley, William
+		  B. and Arnaout, Omar},
+  year		= {2021},
+  month		= jul
+}
+
+@Article{	  mcnaughton_2022,
+  title		= {Quantitative MRI Characterization of the Extremely Preterm
+		  Brain at Adolescence: Atypical versus Neurotypical
+		  Developmental Pathways},
+  volume	= {304},
+  issn		= {1527-1315},
+  url		= {http://dx.doi.org/10.1148/radiol.210385},
+  doi		= {10.1148/radiol.210385},
+  number	= {2},
+  journal	= {Radiology},
+  publisher	= {Radiological Society of North America (RSNA)},
+  author	= {McNaughton, Ryan and Pieper, Chris and Sakai, Osamu and
+		  Rollins, Julie V. and Zhang, Xin and Kennedy, David N. and
+		  Frazier, Jean A. and Douglass, Laurie and Heeren, Timothy
+		  and Fry, Rebecca C. and O’Shea, T. Michael and Kuban,
+		  Karl K. and Jara, Hernán and Rollins, Julie V. and Shah,
+		  Bhavesh and Singh, Rachana and Vaidya, Ruben and Van
+		  Marter, Linda and Martin, Camilla and Ware, Janice and
+		  Rollins, Caitlin and Cole, Cynthia and Perrin, Ellen and
+		  Sakai, Christina and Bednarek, Frank and Frazier, Jean and
+		  Ehrenkranz, Richard and Benjamin, Jennifer and Montgomery,
+		  Angela and O’Shea, T. Michael and Washburn, Lisa and
+		  Gogcu, Semsa and Bose, Carl and Warner, Diane and O’Shea,
+		  T. Michael and Engelke, Steve and Higginson, Amanda and
+		  Higginson, Jason and Bear, Kelly and Poortenga, Mariel and
+		  Pastyrnak, Steve and Karna, Padu and Paneth, Nigel and
+		  Lenski, Madeleine and Schreiber, Michael and Hunter, Scott
+		  and Msall, Michael and Batton, Danny and Klarr, Judith and
+		  Lee, Young Ah and Obeid, Rawad and Christianson, Karen and
+		  Klein, Deborah and Wagner, Katie and Pimental, Maureen and
+		  Hallisey, Collen and Coster, Taryn and Dolins, Maddie and
+		  Mittleman, Maggie and Haile, Hannah and Rohde, Julia and
+		  Nylen, Ellen and Neger, Emily and Mattern, Kathryn and Ma,
+		  Catherine and Toner, Deanna and Vitaro, Elizabeth and
+		  Venuti, Lauren and Powers, Beth and Foley, Ann and Sacco,
+		  Taylor and Williams, Joanne and Romano, Elaine and Henry,
+		  Christine and Hiatt, Debbie and Peters, Nancy and Brown,
+		  Patricia and Ansusinha, Emily and Smith, Jazmyne and Yang,
+		  Nou and Bose, Gennie and Wereszczak, Janice and Bernhardt,
+		  Janice and Adams, Joan and Wilson, Donna and Darden-Saad,
+		  Nancy and Williams, Bree and Jones, Emily and Sutton, Dinah
+		  and Rathbun, Julie and Fagerman, Stephanie and Boshoven,
+		  William and Johnson, Jalen and James, Brandon and Miras,
+		  Karen and Solomon, Carolyn and Weiland, Deborah and Yoon,
+		  Grace and Ramoskaite, Rugile and Wiggins, Suzanne and
+		  Washington, Krissy and Martin, Ryan and Prendergast,
+		  Barbara and Lynch, Emma and Kring, Beth and Smith, Anne and
+		  McQuiston, Susan and Butler, Samantha and Wilson, Rachel
+		  and McGhee, Kirsten and Lee, Patricia and Asgarian, Aimee
+		  and Sadhwani, Anjali and Henson, Brandi and Keller, Cecelia
+		  and Walkowiak, Jenifer and Barron, Susan and Miller, Alice
+		  and Dessureau, Brian and Wood, Molly and Damon-Minow, Jill
+		  and Romano, Elaine and Mayes, Linda and Tsatsanis, Kathy
+		  and Chawarska, Katarzyna and Kim, Sophy and Dieterich,
+		  Susan and Bearrs, Karen and Waldrep, Ellen and Friedman,
+		  Jackie and Hounshell, Gail and Allred, Debbie and Helms,
+		  Rebecca and Whitley, Lynn and Stainback, Gary and Bostic,
+		  Lisa and Jacobson, Amanda and McKeeman, Joni and Meyer,
+		  Echo and Price, Joan and Lloyd, Megan and Plesha-Troyke,
+		  Susan and Scott, Megan and Solomon, Katherine M. and
+		  Brooklier, Kara and Vogt, Kelly},
+  year		= {2022},
+  month		= aug,
+  pages		= {419–428}
+}
+
+@Article{	  millman_2018,
+  title		= {Teaching Computational Reproducibility for Neuroimaging},
+  volume	= {12},
+  issn		= {1662-453X},
+  url		= {http://dx.doi.org/10.3389/fnins.2018.00727},
+  doi		= {10.3389/fnins.2018.00727},
+  journal	= {Frontiers in Neuroscience},
+  publisher	= {Frontiers Media SA},
+  author	= {Millman, K. Jarrod and Brett, Matthew and Barnowski, Ross
+		  and Poline, Jean-Baptiste},
+  year		= {2018},
+  month		= oct
+}
+
+@Article{	  modarres_2021,
+  title		= {Biomarkers Based on Comprehensive Hierarchical EEG
+		  Coherence Analysis: Example Application to Social
+		  Competence in Autism (Preliminary Results)},
+  volume	= {20},
+  issn		= {1559-0089},
+  url		= {http://dx.doi.org/10.1007/s12021-021-09517-8},
+  doi		= {10.1007/s12021-021-09517-8},
+  number	= {1},
+  journal	= {Neuroinformatics},
+  publisher	= {Springer Science and Business Media LLC},
+  author	= {Modarres, Mo and Cochran, David and Kennedy, David N. and
+		  Schmidt, Richard and Fitzpatrick, Paula and Frazier, Jean
+		  A.},
+  year		= {2021},
+  month		= mar,
+  pages		= {53–62}
+}
+
+@Article{	  modarres_2023,
+  title		= {Comparison of comprehensive quantitative EEG metrics
+		  between typically developing boys and girls in resting
+		  state eyes-open and eyes-closed conditions},
+  volume	= {17},
+  issn		= {1662-5161},
+  url		= {http://dx.doi.org/10.3389/fnhum.2023.1237651},
+  doi		= {10.3389/fnhum.2023.1237651},
+  journal	= {Frontiers in Human Neuroscience},
+  publisher	= {Frontiers Media SA},
+  author	= {Modarres, Mo and Cochran, David and Kennedy, David N. and
+		  Frazier, Jean A.},
+  year		= {2023},
+  month		= nov
+}
+
+@Article{	  nastase_2021,
+  title		= {The “Narratives” fMRI dataset for evaluating models of
+		  naturalistic language comprehension},
+  volume	= {8},
+  issn		= {2052-4463},
+  url		= {http://dx.doi.org/10.1038/s41597-021-01033-3},
+  doi		= {10.1038/s41597-021-01033-3},
+  number	= {1},
+  journal	= {Scientific Data},
+  publisher	= {Springer Science and Business Media LLC},
+  author	= {Nastase, Samuel A. and Liu, Yun-Fei and Hillman, Hanna and
+		  Zadbood, Asieh and Hasenfratz, Liat and Keshavarzian,
+		  Neggin and Chen, Janice and Honey, Christopher J. and
+		  Yeshurun, Yaara and Regev, Mor and Nguyen, Mai and Chang,
+		  Claire H. C. and Baldassano, Christopher and Lositsky, Olga
+		  and Simony, Erez and Chow, Michael A. and Leong, Yuan Chang
+		  and Brooks, Paula P. and Micciche, Emily and Choe, Gina and
+		  Goldstein, Ariel and Vanderwal, Tamara and Halchenko,
+		  Yaroslav O. and Norman, Kenneth A. and Hasson, Uri},
+  year		= {2021},
+  month		= sep
+}
+
+@Article{	  nichols_2017,
+  title		= {Best practices in data analysis and sharing in
+		  neuroimaging using MRI},
+  volume	= {20},
+  issn		= {1546-1726},
+  url		= {http://dx.doi.org/10.1038/nn.4500},
+  doi		= {10.1038/nn.4500},
+  number	= {3},
+  journal	= {Nature Neuroscience},
+  publisher	= {Springer Science and Business Media LLC},
+  author	= {Nichols, Thomas E and Das, Samir and Eickhoff, Simon B and
+		  Evans, Alan C and Glatard, Tristan and Hanke, Michael and
+		  Kriegeskorte, Nikolaus and Milham, Michael P and Poldrack,
+		  Russell A and Poline, Jean-Baptiste and Proal, Erika and
+		  Thirion, Bertrand and Van Essen, David C and White, Tonya
+		  and Yeo, B T Thomas},
+  year		= {2017},
+  month		= mar,
+  pages		= {299–303}
+}
+
+@Article{	  niso_2022,
+  title		= {Open and reproducible neuroimaging: From study inception
+		  to publication},
+  volume	= {263},
+  issn		= {1053-8119},
+  url		= {http://dx.doi.org/10.1016/j.neuroimage.2022.119623},
+  doi		= {10.1016/j.neuroimage.2022.119623},
+  journal	= {NeuroImage},
+  publisher	= {Elsevier BV},
+  author	= {Niso, Guiomar and Botvinik-Nezer, Rotem and Appelhoff,
+		  Stefan and De La Vega, Alejandro and Esteban, Oscar and
+		  Etzel, Joset A. and Finc, Karolina and Ganz, Melanie and
+		  Gau, Rémi and Halchenko, Yaroslav O. and Herholz, Peer and
+		  Karakuzu, Agah and Keator, David B. and Markiewicz,
+		  Christopher J. and Maumet, Camille and Pernet, Cyril R. and
+		  Pestilli, Franco and Queder, Nazek and Schmitt, Tina and
+		  Sójka, Weronika and Wagner, Adina S. and Whitaker, Kirstie
+		  J. and Rieger, Jochem W.},
+  year		= {2022},
+  month		= nov,
+  pages		= {119623}
+}
+
+@Article{	  notter_2022,
+  title		= {fMRIflows: A Consortium of Fully Automatic Univariate and
+		  Multivariate fMRI Processing Pipelines},
+  volume	= {36},
+  issn		= {1573-6792},
+  url		= {http://dx.doi.org/10.1007/s10548-022-00935-8},
+  doi		= {10.1007/s10548-022-00935-8},
+  number	= {2},
+  journal	= {Brain Topography},
+  publisher	= {Springer Science and Business Media LLC},
+  author	= {Notter, Michael P. and Herholz, Peer and Da Costa, Sandra
+		  and Gulban, Omer F. and Isik, Ayse Ilkay and Gaglianese,
+		  Anna and Murray, Micah M.},
+  year		= {2022},
+  month		= dec,
+  pages		= {172–191}
+}
+
+@Article{	  ozyurt_2018,
+  title		= {Foundry: a message-oriented, horizontally scalable ETL
+		  system for scientific data integration and enhancement},
+  volume	= {2018},
+  issn		= {1758-0463},
+  url		= {http://dx.doi.org/10.1093/database/bay130},
+  doi		= {10.1093/database/bay130},
+  journal	= {Database},
+  publisher	= {Oxford University Press (OUP)},
+  author	= {Ozyurt, Ibrahim Burak and Grethe, Jeffrey S},
+  year		= {2018},
+  month		= jan
+}
+
+@Article{	  peraza_2023,
+  title		= {Methods for decoding cortical gradients of functional
+		  connectivity},
+  url		= {http://dx.doi.org/10.1101/2023.08.01.551505},
+  doi		= {10.1101/2023.08.01.551505},
+  publisher	= {Cold Spring Harbor Laboratory},
+  author	= {Peraza, Julio A. and Salo, Taylor and Riedel, Michael C.
+		  and Bottenhorn, Katherine L. and Poline, Jean-Baptiste and
+		  Dockès, Jérôme and Kent, James D. and Bartley, Jessica
+		  E. and Flannery, Jessica S. and Hill-Bowen, Lauren D. and
+		  Lobo, Rosario Pintos and Poudel, Ranjita and Ray, Kimberly
+		  L. and Robinson, Jennifer L. and Laird, Robert W. and
+		  Sutherland, Matthew T. and de la Vega, Alejandro and Laird,
+		  Angela R.},
+  year		= {2023},
+  month		= aug
+}
+
+@Article{	  perez_lebel_2022,
+  title		= {Benchmarking missing-values approaches for predictive
+		  models on health databases},
+  volume	= {11},
+  issn		= {2047-217X},
+  url		= {http://dx.doi.org/10.1093/gigascience/giac013},
+  doi		= {10.1093/gigascience/giac013},
+  journal	= {GigaScience},
+  publisher	= {Oxford University Press (OUP)},
+  author	= {Perez-Lebel, Alexandre and Varoquaux, Gaël and
+		  Le Morvan, Marine and Josse, Julie and Poline,
+		  Jean-Baptiste},
+  year		= {2022}
+}
+
+@Article{	  poldrack_2017,
+  title		= {Scanning the horizon: towards transparent and reproducible
+		  neuroimaging research},
+  volume	= {18},
+  issn		= {1471-0048},
+  url		= {http://dx.doi.org/10.1038/nrn.2016.167},
+  doi		= {10.1038/nrn.2016.167},
+  number	= {2},
+  journal	= {Nature Reviews Neuroscience},
+  publisher	= {Springer Science and Business Media LLC},
+  author	= {Poldrack, Russell A. and Baker, Chris I. and Durnez, Joke
+		  and Gorgolewski, Krzysztof J. and Matthews, Paul M. and
+		  Munafò, Marcus R. and Nichols, Thomas E. and Poline,
+		  Jean-Baptiste and Vul, Edward and Yarkoni, Tal},
+  year		= {2017},
+  month		= jan,
+  pages		= {115–126}
+}
+
+@Article{	  poldrack_2024,
+  title		= {The past, present, and future of the brain imaging data
+		  structure (BIDS)},
+  volume	= {2},
+  issn		= {2837-6056},
+  url		= {http://dx.doi.org/10.1162/imag_a_00103},
+  doi		= {10.1162/imag_a_00103},
+  journal	= {Imaging Neuroscience},
+  publisher	= {MIT Press},
+  author	= {Poldrack, Russell A. and Markiewicz, Christopher J. and
+		  Appelhoff, Stefan and Ashar, Yoni K. and Auer, Tibor and
+		  Baillet, Sylvain and Bansal, Shashank and Beltrachini,
+		  Leandro and Benar, Christian G. and Bertazzoli, Giacomo and
+		  Bhogawar, Suyash and Blair, Ross W. and Bortoletto, Marta
+		  and Boudreau, Mathieu and Brooks, Teon L. and Calhoun,
+		  Vince D. and Castelli, Filippo Maria and Clement, Patricia
+		  and Cohen, Alexander L. and Cohen-Adad, Julien and
+		  D’Ambrosio, Sasha and de Hollander, Gilles and de la
+		  Iglesia-Vayá, María and de la Vega, Alejandro and
+		  Delorme, Arnaud and Devinsky, Orrin and Draschkow, Dejan
+		  and Duff, Eugene Paul and DuPre, Elizabeth and Earl, Eric
+		  and Esteban, Oscar and Feingold, Franklin W. and Flandin,
+		  Guillaume and Galassi, Anthony and Gallitto, Giuseppe and
+		  Ganz, Melanie and Gau, Rémi and Gholam, James and Ghosh,
+		  Satrajit S. and Giacomel, Alessio and Gillman, Ashley G.
+		  and Gleeson, Padraig and Gramfort, Alexandre and Guay,
+		  Samuel and Guidali, Giacomo and Halchenko, Yaroslav O. and
+		  Handwerker, Daniel A. and Hardcastle, Nell and Herholz,
+		  Peer and Hermes, Dora and Honey, Christopher J. and Innis,
+		  Robert B. and Ioanas, Horea-Ioan and Jahn, Andrew and
+		  Karakuzu, Agah and Keator, David B. and Kiar, Gregory and
+		  Kincses, Balint and Laird, Angela R. and Lau, Jonathan C.
+		  and Lazari, Alberto and Legarreta, Jon Haitz and Li, Adam
+		  and Li, Xiangrui and Love, Bradley C. and Lu, Hanzhang and
+		  Marcantoni, Eleonora and Maumet, Camille and Mazzamuto,
+		  Giacomo and Meisler, Steven L. and Mikkelsen, Mark and
+		  Mutsaerts, Henk and Nichols, Thomas E. and Nikolaidis, Aki
+		  and Nilsonne, Gustav and Niso, Guiomar and Norgaard, Martin
+		  and Okell, Thomas W. and Oostenveld, Robert and Ort, Eduard
+		  and Park, Patrick J. and Pawlik, Mateusz and Pernet, Cyril
+		  R. and Pestilli, Franco and Petr, Jan and Phillips,
+		  Christophe and Poline, Jean-Baptiste and Pollonini, Luca
+		  and Raamana, Pradeep Reddy and Ritter, Petra and Rizzo,
+		  Gaia and Robbins, Kay A. and Rockhill, Alexander P. and
+		  Rogers, Christine and Rokem, Ariel and Rorden, Chris and
+		  Routier, Alexandre and Saborit-Torres, Jose Manuel and
+		  Salo, Taylor and Schirner, Michael and Smith, Robert E. and
+		  Spisak, Tamas and Sprenger, Julia and Swann, Nicole C. and
+		  Szinte, Martin and Takerkart, Sylvain and Thirion, Bertrand
+		  and Thomas, Adam G. and Torabian, Sajjad and Varoquaux,
+		  Gael and Voytek, Bradley and Welzel, Julius and Wilson,
+		  Martin and Yarkoni, Tal and Gorgolewski, Krzysztof J.},
+  year		= {2024},
+  month		= mar,
+  pages		= {1–19}
+}
+
+@Article{	  poline_2019,
+  title		= {From data sharing to data publishing},
+  volume	= {2},
+  issn		= {2515-5059},
+  url		= {http://dx.doi.org/10.12688/mniopenres.12772.2},
+  doi		= {10.12688/mniopenres.12772.2},
+  journal	= {MNI Open Research},
+  publisher	= {F1000 Research Ltd},
+  author	= {Poline, Jean-Baptiste},
+  year		= {2019},
+  month		= jan,
+  pages		= {1}
+}
+
+@Article{	  poline_2022,
+  title		= {Is Neuroscience FAIR? A Call for Collaborative
+		  Standardisation of Neuroscience Data},
+  volume	= {20},
+  issn		= {1559-0089},
+  url		= {http://dx.doi.org/10.1007/s12021-021-09557-0},
+  doi		= {10.1007/s12021-021-09557-0},
+  number	= {2},
+  journal	= {Neuroinformatics},
+  publisher	= {Springer Science and Business Media LLC},
+  author	= {Poline, Jean-Baptiste and Kennedy, David N. and Sommer,
+		  Friedrich T. and Ascoli, Giorgio A. and Van Essen, David C.
+		  and Ferguson, Adam R. and Grethe, Jeffrey S. and Hawrylycz,
+		  Michael J. and Thompson, Paul M. and Poldrack, Russell A.
+		  and Ghosh, Satrajit S. and Keator, David B. and Athey,
+		  Thomas L. and Vogelstein, Joshua T. and Mayberg, Helen S.
+		  and Martone, Maryann E.},
+  year		= {2022},
+  month		= jan,
+  pages		= {507–512}
+}
+
+@Article{	  poline_2023,
+  title		= {Data and Tools Integration in the Canadian Open
+		  Neuroscience Platform},
+  volume	= {10},
+  issn		= {2052-4463},
+  url		= {http://dx.doi.org/10.1038/s41597-023-01946-1},
+  doi		= {10.1038/s41597-023-01946-1},
+  number	= {1},
+  journal	= {Scientific Data},
+  publisher	= {Springer Science and Business Media LLC},
+  author	= {Poline, Jean-Baptiste and Das, Samir and Glatard, Tristan
+		  and Madjar, Cécile and Dickie, Erin W. and Lecours, Xavier
+		  and Beaudry, Thomas and Beck, Natacha and Behan, Brendan
+		  and Brown, Shawn T. and Bujold, David and Beauvais, Michael
+		  and Caron, Bryan and Czech, Candice and Dharsee, Moyez and
+		  Dugré, Mathieu and Evans, Ken and Gee, Tom and Ippoliti,
+		  Giulia and Kiar, Gregory and Knoppers, Bartha Maria and
+		  Kuehn, Tristan and Le, Diana and Lo, Derek and Mazaheri,
+		  Mandana and MacFarlane, Dave and Muja, Naser and O’Brien,
+		  Emmet A. and O’Callaghan, Liam and Paiva, Santiago and
+		  Park, Patrick and Quesnel, Darcy and Rabelais, Henri and
+		  Rioux, Pierre and Legault, Mélanie and Tremblay-Mercier,
+		  Jennifer and Rotenberg, David and Stone, Jessica and
+		  Strauss, Ted and Zaytseva, Ksenia and Zhou, Joey and
+		  Duchesne, Simon and Khan, Ali R. and Hill, Sean and Evans,
+		  Alan C.},
+  year		= {2023},
+  month		= apr
+}
+
+@Article{	  queder_2023,
+  title		= {NIDM-Terms: community-based terminology management for
+		  improved neuroimaging dataset descriptions and query},
+  volume	= {17},
+  issn		= {1662-5196},
+  url		= {http://dx.doi.org/10.3389/fninf.2023.1174156},
+  doi		= {10.3389/fninf.2023.1174156},
+  journal	= {Frontiers in Neuroinformatics},
+  publisher	= {Frontiers Media SA},
+  author	= {Queder, Nazek and Tien, Vivian B. and Abraham, Sanu Ann
+		  and Urchs, Sebastian Georg Wenzel and Helmer, Karl G. and
+		  Chaplin, Derek and van Erp, Theo G. M. and Kennedy, David
+		  N. and Poline, Jean-Baptiste and Grethe, Jeffrey S. and
+		  Ghosh, Satrajit S. and Keator, David B.},
+  year		= {2023},
+  month		= jul
+}
+
+@Article{	  renton_2024,
+  title		= {Neurodesk: an accessible, flexible and portable data
+		  analysis environment for reproducible neuroimaging},
+  volume	= {21},
+  issn		= {1548-7105},
+  url		= {http://dx.doi.org/10.1038/s41592-023-02145-x},
+  doi		= {10.1038/s41592-023-02145-x},
+  number	= {5},
+  journal	= {Nature Methods},
+  publisher	= {Springer Science and Business Media LLC},
+  author	= {Renton, Angela I. and Dao, Thuy T. and Johnstone, Tom and
+		  Civier, Oren and Sullivan, Ryan P. and White, David J. and
+		  Lyons, Paris and Slade, Benjamin M. and Abbott, David F.
+		  and Amos, Toluwani J. and Bollmann, Saskia and Botting,
+		  Andy and Campbell, Megan E. J. and Chang, Jeryn and Close,
+		  Thomas G. and Dörig, Monika and Eckstein, Korbinian and
+		  Egan, Gary F. and Evas, Stefanie and Flandin, Guillaume and
+		  Garner, Kelly G. and Garrido, Marta I. and Ghosh, Satrajit
+		  S. and Grignard, Martin and Halchenko, Yaroslav O. and
+		  Hannan, Anthony J. and Heinsfeld, Anibal S. and Huber,
+		  Laurentius and Hughes, Matthew E. and Kaczmarzyk, Jakub R.
+		  and Kasper, Lars and Kuhlmann, Levin and Lou, Kexin and
+		  Mantilla-Ramos, Yorguin-Jose and Mattingley, Jason B. and
+		  Meier, Michael L. and Morris, Jo and Narayanan, Akshaiy and
+		  Pestilli, Franco and Puce, Aina and Ribeiro, Fernanda L.
+		  and Rogasch, Nigel C. and Rorden, Chris and Schira, Mark M.
+		  and Shaw, Thomas B. and Sowman, Paul F. and Spitz, Gershon
+		  and Stewart, Ashley W. and Ye, Xincheng and Zhu, Judy D.
+		  and Narayanan, Aswin and Bollmann, Steffen},
+  year		= {2024},
+  month		= jan,
+  pages		= {804–808}
+}
+
+@Article{	  royer_2022,
+  title		= {An Open MRI Dataset For Multiscale Neuroscience},
+  volume	= {9},
+  issn		= {2052-4463},
+  url		= {http://dx.doi.org/10.1038/s41597-022-01682-y},
+  doi		= {10.1038/s41597-022-01682-y},
+  number	= {1},
+  journal	= {Scientific Data},
+  publisher	= {Springer Science and Business Media LLC},
+  author	= {Royer, Jessica and Rodríguez-Cruces, Raúl and Tavakol,
+		  Shahin and Larivière, Sara and Herholz, Peer and Li,
+		  Qiongling and Vos de Wael, Reinder and Paquola, Casey and
+		  Benkarim, Oualid and Park, Bo-yong and Lowe, Alexander J.
+		  and Margulies, Daniel and Smallwood, Jonathan and
+		  Bernasconi, Andrea and Bernasconi, Neda and Frauscher,
+		  Birgit and Bernhardt, Boris C.},
+  year		= {2022},
+  month		= sep
+}
+
+@Article{	  sansone_2017,
+  title		= {DATS, the data tag suite to enable discoverability of
+		  datasets},
+  volume	= {4},
+  issn		= {2052-4463},
+  url		= {http://dx.doi.org/10.1038/sdata.2017.59},
+  doi		= {10.1038/sdata.2017.59},
+  number	= {1},
+  journal	= {Scientific Data},
+  publisher	= {Springer Science and Business Media LLC},
+  author	= {Sansone, Susanna-Assunta and Gonzalez-Beltran, Alejandra
+		  and Rocca-Serra, Philippe and Alter, George and Grethe,
+		  Jeffrey S. and Xu, Hua and Fore, Ian M. and Lyle, Jared and
+		  Gururaj, Anupama E. and Chen, Xiaoling and Kim, Hyeon-eui
+		  and Zong, Nansu and Li, Yueling and Liu, Ruiling and
+		  Ozyurt, I. Burak and Ohno-Machado, Lucila},
+  year		= {2017},
+  month		= jun
+}
+
+@Article{	  satz_2022,
+  title		= {The Relationship Between Default Mode and Dorsal Attention
+		  Networks Is Associated With Depressive Disorder Diagnosis
+		  and the Strength of Memory Representations Acquired Prior
+		  to the Resting State Scan},
+  volume	= {16},
+  issn		= {1662-5161},
+  url		= {http://dx.doi.org/10.3389/fnhum.2022.749767},
+  doi		= {10.3389/fnhum.2022.749767},
+  journal	= {Frontiers in Human Neuroscience},
+  publisher	= {Frontiers Media SA},
+  author	= {Satz, Skye and Halchenko, Yaroslav O. and Ragozzino,
+		  Rachel and Lucero, Mora M. and Phillips, Mary L. and
+		  Swartz, Holly A. and Manelis, Anna},
+  year		= {2022},
+  month		= feb
+}
+
+@Article{	  siless_2020,
+  title		= {Image acquisition and quality assurance in the Boston
+		  Adolescent Neuroimaging of Depression and Anxiety study},
+  volume	= {26},
+  issn		= {2213-1582},
+  url		= {http://dx.doi.org/10.1016/j.nicl.2020.102242},
+  doi		= {10.1016/j.nicl.2020.102242},
+  journal	= {NeuroImage: Clinical},
+  publisher	= {Elsevier BV},
+  author	= {Siless, Viviana and Hubbard, Nicholas A. and Jones, Robert
+		  and Wang, Jonathan and Lo, Nicole and Bauer, Clemens C.C.
+		  and Goncalves, Mathias and Frosch, Isabelle and Norton,
+		  Daniel and Vergara, Genesis and Conroy, Kristina and De
+		  Souza, Flavia Vaz and Rosso, Isabelle M. and Wickham,
+		  Aleena Hay and Cosby, Elizabeth Ann and Pinaire, Megan and
+		  Hirshfeld-Becker, Dina and Pizzagalli, Diego A. and Henin,
+		  Aude and Hofmann, Stefan G. and Auerbach, Randy P. and
+		  Ghosh, Satrajit and Gabrieli, John and Whitfield-Gabrieli,
+		  Susan and Yendiki, Anastasia},
+  year		= {2020},
+  pages		= {102242}
+}
+
+@Article{	  sitek_2019,
+  title		= {Mapping the human subcortical auditory system using
+		  histology, postmortem MRI and in vivo MRI at 7T},
+  volume	= {8},
+  issn		= {2050-084X},
+  url		= {http://dx.doi.org/10.7554/elife.48932},
+  doi		= {10.7554/elife.48932},
+  journal	= {eLife},
+  publisher	= {eLife Sciences Publications, Ltd},
+  author	= {Sitek, Kevin R and Gulban, Omer Faruk and Calabrese, Evan
+		  and Johnson, G Allan and Lage-Castellanos, Agustin and
+		  Moerel, Michelle and Ghosh, Satrajit S and De Martino,
+		  Federico},
+  year		= {2019},
+  month		= aug
+}
+
+@Article{	  soko_owski_2024,
+  title		= {Longitudinal brain structure changes in Parkinson’s
+		  disease: A replication study},
+  volume	= {19},
+  issn		= {1932-6203},
+  url		= {http://dx.doi.org/10.1371/journal.pone.0295069},
+  doi		= {10.1371/journal.pone.0295069},
+  number	= {1},
+  journal	= {PLOS ONE},
+  publisher	= {Public Library of Science (PLoS)},
+  author	= {Sokołowski, Andrzej and Bhagwat, Nikhil and Chatelain,
+		  Yohan and Dugré, Mathieu and Hanganu, Alexandru and
+		  Monchi, Oury and McPherson, Brent and Wang, Michelle and
+		  Poline, Jean-Baptiste and Sharp, Madeleine and Glatard,
+		  Tristan},
+  editor	= {Bergsland, Niels},
+  year		= {2024},
+  month		= jan,
+  pages		= {e0295069}
+}
+
+@Article{	  solo_2018,
+  title		= {Connectivity in fMRI: Blind Spots and Breakthroughs},
+  volume	= {37},
+  issn		= {1558-254X},
+  url		= {http://dx.doi.org/10.1109/tmi.2018.2831261},
+  doi		= {10.1109/tmi.2018.2831261},
+  number	= {7},
+  journal	= {IEEE Transactions on Medical Imaging},
+  publisher	= {Institute of Electrical and Electronics Engineers (IEEE)},
+  author	= {Solo, Victor and Poline, Jean-Baptiste and Lindquist,
+		  Martin A. and Simpson, Sean L. and Bowman, F. DuBois and
+		  Chung, Moo K. and Cassidy, Ben},
+  year		= {2018},
+  month		= jul,
+  pages		= {1537–1550}
+}
+
+@Article{	  szczepanik_2024,
+  title		= {Teaching Research Data Management with DataLad: A
+		  Multi-year, Multi-domain Effort},
+  volume	= {22},
+  issn		= {1559-0089},
+  url		= {http://dx.doi.org/10.1007/s12021-024-09665-7},
+  doi		= {10.1007/s12021-024-09665-7},
+  number	= {4},
+  journal	= {Neuroinformatics},
+  publisher	= {Springer Science and Business Media LLC},
+  author	= {Szczepanik, Michał and Wagner, Adina S. and Heunis,
+		  Stephan and Waite, Laura K. and Eickhoff, Simon B. and
+		  Hanke, Michael},
+  year		= {2024},
+  month		= may,
+  pages		= {635–645}
+}
+
+@Article{	  torabi_2024,
+  title		= {On the variability of dynamic functional connectivity
+		  assessment methods},
+  volume	= {13},
+  issn		= {2047-217X},
+  url		= {http://dx.doi.org/10.1093/gigascience/giae009},
+  doi		= {10.1093/gigascience/giae009},
+  journal	= {GigaScience},
+  publisher	= {Oxford University Press (OUP)},
+  author	= {Torabi, Mohammad and Mitsis, Georgios D and Poline,
+		  Jean-Baptiste},
+  year		= {2024}
+}
+
+@Article{	  torabian_2023,
+  title		= {The PyMVPA BIDS-App: a robust multivariate pattern
+		  analysis pipeline for fMRI data},
+  volume	= {17},
+  issn		= {1662-453X},
+  url		= {http://dx.doi.org/10.3389/fnins.2023.1233416},
+  doi		= {10.3389/fnins.2023.1233416},
+  journal	= {Frontiers in Neuroscience},
+  publisher	= {Frontiers Media SA},
+  author	= {Torabian, Sajjad and Vélez, Natalia and Sochat, Vanessa
+		  and Halchenko, Yaroslav O. and Grossman, Emily D.},
+  year		= {2023},
+  month		= aug
+}
+
+@Article{	  torres_esp_n_2021,
+  title		= {Promoting FAIR Data Through Community-driven Agile Design:
+		  the Open Data Commons for Spinal Cord Injury
+		  (odc-sci.org)},
+  volume	= {20},
+  issn		= {1559-0089},
+  url		= {http://dx.doi.org/10.1007/s12021-021-09533-8},
+  doi		= {10.1007/s12021-021-09533-8},
+  number	= {1},
+  journal	= {Neuroinformatics},
+  publisher	= {Springer Science and Business Media LLC},
+  author	= {Torres-Espín, Abel and Almeida, Carlos A. and Chou,
+		  Austin and Huie, J. Russell and Chiu, Michael and Vavrek,
+		  Romana and Sacramento, Jeff and Orr, Michael B. and Gensel,
+		  John C. and Grethe, Jeffery S. and Martone, Maryann E. and
+		  Fouad, Karim and Ferguson, Adam R. and Alilain, Warren and
+		  Bacon, Mark and Batty, Nicholas and Beattie, Michael and
+		  Bresnahan, Jacqueline and Burnside, Emily and Busch, Sarah
+		  and Carpenter, Randall and Quijorna, Isaac Francos and Guo,
+		  Xiaohui and Haggerty, Agnes and Haroon, Sarah and Harris,
+		  Jack and Jakeman, Lyn and Jones, Linda and Kleitman, Naomi
+		  and Kopper, Timothy and Lane, Michael and Magana, Francisco
+		  and Magnuson, David and Maldonado, Ines and May, Verena and
+		  McFarlane, Katelyn and Morioka, Kazuhito and Oudega, Martin
+		  and Pascual, Philip Leo and Poline, Jean-Baptiste and
+		  Rosenzweig, Ephron and Schmidt, Emma and Tetzlaff, Wolfram
+		  and Zholudeva, Lana},
+  year		= {2021},
+  month		= aug,
+  pages		= {203–219}
+}
+
+@Article{	  wang_2023,
+  title		= {Reproducibility of cerebellar involvement as quantified by
+		  consensus structural MRI biomarkers in advanced essential
+		  tremor},
+  volume	= {13},
+  issn		= {2045-2322},
+  url		= {http://dx.doi.org/10.1038/s41598-022-25306-y},
+  doi		= {10.1038/s41598-022-25306-y},
+  number	= {1},
+  journal	= {Scientific Reports},
+  publisher	= {Springer Science and Business Media LLC},
+  author	= {Wang, Qing and Aljassar, Meshal and Bhagwat, Nikhil and
+		  Zeighami, Yashar and Evans, Alan C. and Dagher, Alain and
+		  Pike, G. Bruce and Sadikot, Abbas F. and Poline,
+		  Jean-Baptiste},
+  year		= {2023},
+  month		= jan
+}
+
+@Article{	  wimalaratne_2018,
+  title		= {Uniform resolution of compact identifiers for biomedical
+		  data},
+  volume	= {5},
+  issn		= {2052-4463},
+  url		= {http://dx.doi.org/10.1038/sdata.2018.29},
+  doi		= {10.1038/sdata.2018.29},
+  number	= {1},
+  journal	= {Scientific Data},
+  publisher	= {Springer Science and Business Media LLC},
+  author	= {Wimalaratne, Sarala M. and Juty, Nick and Kunze, John and
+		  Janée, Greg and McMurry, Julie A. and Beard, Niall and
+		  Jimenez, Rafael and Grethe, Jeffrey S. and Hermjakob,
+		  Henning and Martone, Maryann E. and Clark, Tim},
+  year		= {2018},
+  month		= may
+}
+
+@Article{	  yarkoni_2019,
+  title		= {PyBIDS: Python tools for BIDS datasets},
+  volume	= {4},
+  issn		= {2475-9066},
+  url		= {http://dx.doi.org/10.21105/joss.01294},
+  doi		= {10.21105/joss.01294},
+  number	= {40},
+  journal	= {Journal of Open Source Software},
+  publisher	= {The Open Journal},
+  author	= {Yarkoni, Tal and Markiewicz, Christopher and de la Vega,
+		  Alejandro and Gorgolewski, Krzysztof and Salo, Taylor and
+		  Halchenko, Yaroslav and McNamara, Quinten and DeStasio,
+		  Krista and Poline, Jean-Baptiste and Petrov, Dmitry and
+		  Hayot-Sasson, Valérie and Nielson, Dylan and Carlin, Johan
+		  and Kiar, Gregory and Whitaker, Kirstie and DuPre,
+		  Elizabeth and Wagner, Adina and Tirrell, Lee and Jas,
+		  Mainak and Hanke, Michael and Poldrack, Russell and
+		  Esteban, Oscar and Appelhoff, Stefan and Holdgraf, Chris
+		  and Staden, Isla and Thirion, Bertrand and Kleinschmidt,
+		  Dave and Lee, John and di Castello, Matteo and Notter,
+		  Michael and Blair, Ross},
+  year		= {2019},
+  month		= aug,
+  pages		= {1294}
+}
+
+@Article{	  zhao_2023,
+  title		= {A reproducible and generalizable software workflow for
+		  analysis of large-scale neuroimaging data collections using
+		  BIDS Apps},
+  url		= {http://dx.doi.org/10.1101/2023.08.16.552472},
+  doi		= {10.1101/2023.08.16.552472},
+  publisher	= {Cold Spring Harbor Laboratory},
+  author	= {Zhao, Chenying and Jarecka, Dorota and Covitz, Sydney and
+		  Chen, Yibei and Eickhoff, Simon B. and Fair, Damien A. and
+		  Franco, Alexandre R. and Halchenko, Yaroslav O. and
+		  Hendrickson, Timothy J. and Hoffstaedter, Felix and
+		  Houghton, Audrey and Kiar, Gregory and Macdonald, Austin
+		  and Mehta, Kahini and Milham, Michael P. and Salo, Taylor
+		  and Hanke, Michael and Ghosh, Satrajit S. and Cieslak,
+		  Matthew and Satterthwaite, Theodore D.},
+  year		= {2023},
+  month		= aug
+}

--- a/content/publications/queder-2023/cite.bib
+++ b/content/publications/queder-2023/cite.bib
@@ -1,0 +1,17 @@
+@article{queder_2023,
+ author = {Queder, Nazek and Tien, Vivian B. and Abraham, Sanu Ann
+and Urchs, Sebastian Georg Wenzel and Helmer, Karl G. and
+Chaplin, Derek and van Erp, Theo G. M. and Kennedy, David
+N. and Poline, Jean-Baptiste and Grethe, Jeffrey S. and
+Ghosh, Satrajit S. and Keator, David B.},
+ doi = {10.3389/fninf.2023.1174156},
+ issn = {1662-5196},
+ journal = {Frontiers in Neuroinformatics},
+ month = {July},
+ publisher = {Frontiers Media SA},
+ title = {NIDM-Terms: community-based terminology management for
+improved neuroimaging dataset descriptions and query},
+ url = {http://dx.doi.org/10.3389/fninf.2023.1174156},
+ volume = {17},
+ year = {2023}
+}

--- a/content/publications/queder-2023/index.md
+++ b/content/publications/queder-2023/index.md
@@ -1,0 +1,26 @@
+---
+title: 'NIDM-Terms: community-based terminology management for improved neuroimaging
+  dataset descriptions and query'
+authors:
+- Nazek Queder
+- Vivian B. Tien
+- Sanu Ann Abraham
+- Sebastian Georg Wenzel Urchs
+- Karl G. Helmer
+- Derek Chaplin
+- Theo G. M. van Erp
+- David N. Kennedy
+- Jean-Baptiste Poline
+- Jeffrey S. Grethe
+- Satrajit S. Ghosh
+- David B. Keator
+date: '2023-07-01'
+publishDate: '2024-12-19T23:16:36.706771Z'
+publication_types:
+- article-journal
+publication: '*Frontiers in Neuroinformatics*'
+doi: 10.3389/fninf.2023.1174156
+links:
+- name: URL
+  url: http://dx.doi.org/10.3389/fninf.2023.1174156
+---

--- a/content/publications/renton-2024/cite.bib
+++ b/content/publications/renton-2024/cite.bib
@@ -1,0 +1,33 @@
+@article{renton_2024,
+ author = {Renton, Angela I. and Dao, Thuy T. and Johnstone, Tom and
+Civier, Oren and Sullivan, Ryan P. and White, David J. and
+Lyons, Paris and Slade, Benjamin M. and Abbott, David F.
+and Amos, Toluwani J. and Bollmann, Saskia and Botting,
+Andy and Campbell, Megan E. J. and Chang, Jeryn and Close,
+Thomas G. and Dörig, Monika and Eckstein, Korbinian and
+Egan, Gary F. and Evas, Stefanie and Flandin, Guillaume and
+Garner, Kelly G. and Garrido, Marta I. and Ghosh, Satrajit
+S. and Grignard, Martin and Halchenko, Yaroslav O. and
+Hannan, Anthony J. and Heinsfeld, Anibal S. and Huber,
+Laurentius and Hughes, Matthew E. and Kaczmarzyk, Jakub R.
+and Kasper, Lars and Kuhlmann, Levin and Lou, Kexin and
+Mantilla-Ramos, Yorguin-Jose and Mattingley, Jason B. and
+Meier, Michael L. and Morris, Jo and Narayanan, Akshaiy and
+Pestilli, Franco and Puce, Aina and Ribeiro, Fernanda L.
+and Rogasch, Nigel C. and Rorden, Chris and Schira, Mark M.
+and Shaw, Thomas B. and Sowman, Paul F. and Spitz, Gershon
+and Stewart, Ashley W. and Ye, Xincheng and Zhu, Judy D.
+and Narayanan, Aswin and Bollmann, Steffen},
+ doi = {10.1038/s41592-023-02145-x},
+ issn = {1548-7105},
+ journal = {Nature Methods},
+ month = {January},
+ number = {5},
+ pages = {804–808},
+ publisher = {Springer Science and Business Media LLC},
+ title = {Neurodesk: an accessible, flexible and portable data
+analysis environment for reproducible neuroimaging},
+ url = {http://dx.doi.org/10.1038/s41592-023-02145-x},
+ volume = {21},
+ year = {2024}
+}

--- a/content/publications/renton-2024/index.md
+++ b/content/publications/renton-2024/index.md
@@ -1,0 +1,66 @@
+---
+title: 'Neurodesk: an accessible, flexible and portable data analysis environment
+  for reproducible neuroimaging'
+authors:
+- Angela I. Renton
+- Thuy T. Dao
+- Tom Johnstone
+- Oren Civier
+- Ryan P. Sullivan
+- David J. White
+- Paris Lyons
+- Benjamin M. Slade
+- David F. Abbott
+- Toluwani J. Amos
+- Saskia Bollmann
+- Andy Botting
+- Megan E. J. Campbell
+- Jeryn Chang
+- Thomas G. Close
+- Monika Dörig
+- Korbinian Eckstein
+- Gary F. Egan
+- Stefanie Evas
+- Guillaume Flandin
+- Kelly G. Garner
+- Marta I. Garrido
+- Satrajit S. Ghosh
+- Martin Grignard
+- Yaroslav O. Halchenko
+- Anthony J. Hannan
+- Anibal S. Heinsfeld
+- Laurentius Huber
+- Matthew E. Hughes
+- Jakub R. Kaczmarzyk
+- Lars Kasper
+- Levin Kuhlmann
+- Kexin Lou
+- Yorguin-Jose Mantilla-Ramos
+- Jason B. Mattingley
+- Michael L. Meier
+- Jo Morris
+- Akshaiy Narayanan
+- Franco Pestilli
+- Aina Puce
+- Fernanda L. Ribeiro
+- Nigel C. Rogasch
+- Chris Rorden
+- Mark M. Schira
+- Thomas B. Shaw
+- Paul F. Sowman
+- Gershon Spitz
+- Ashley W. Stewart
+- Xincheng Ye
+- Judy D. Zhu
+- Aswin Narayanan
+- Steffen Bollmann
+date: '2024-01-01'
+publishDate: '2024-12-19T23:16:36.710906Z'
+publication_types:
+- article-journal
+publication: '*Nature Methods*'
+doi: 10.1038/s41592-023-02145-x
+links:
+- name: URL
+  url: http://dx.doi.org/10.1038/s41592-023-02145-x
+---

--- a/content/publications/royer-2022/cite.bib
+++ b/content/publications/royer-2022/cite.bib
@@ -1,0 +1,19 @@
+@article{royer_2022,
+ author = {Royer, Jessica and Rodríguez-Cruces, Raúl and Tavakol,
+Shahin and Larivière, Sara and Herholz, Peer and Li,
+Qiongling and Vos de Wael, Reinder and Paquola, Casey and
+Benkarim, Oualid and Park, Bo-yong and Lowe, Alexander J.
+and Margulies, Daniel and Smallwood, Jonathan and
+Bernasconi, Andrea and Bernasconi, Neda and Frauscher,
+Birgit and Bernhardt, Boris C.},
+ doi = {10.1038/s41597-022-01682-y},
+ issn = {2052-4463},
+ journal = {Scientific Data},
+ month = {September},
+ number = {1},
+ publisher = {Springer Science and Business Media LLC},
+ title = {An Open MRI Dataset For Multiscale Neuroscience},
+ url = {http://dx.doi.org/10.1038/s41597-022-01682-y},
+ volume = {9},
+ year = {2022}
+}

--- a/content/publications/royer-2022/index.md
+++ b/content/publications/royer-2022/index.md
@@ -1,0 +1,30 @@
+---
+title: An Open MRI Dataset For Multiscale Neuroscience
+authors:
+- Jessica Royer
+- Raúl Rodríguez-Cruces
+- Shahin Tavakol
+- Sara Larivière
+- Peer Herholz
+- Qiongling Li
+- Reinder Vos de Wael
+- Casey Paquola
+- Oualid Benkarim
+- Bo-yong Park
+- Alexander J. Lowe
+- Daniel Margulies
+- Jonathan Smallwood
+- Andrea Bernasconi
+- Neda Bernasconi
+- Birgit Frauscher
+- Boris C. Bernhardt
+date: '2022-09-01'
+publishDate: '2024-12-19T23:16:36.715798Z'
+publication_types:
+- article-journal
+publication: '*Scientific Data*'
+doi: 10.1038/s41597-022-01682-y
+links:
+- name: URL
+  url: http://dx.doi.org/10.1038/s41597-022-01682-y
+---

--- a/content/publications/sansone-2017/cite.bib
+++ b/content/publications/sansone-2017/cite.bib
@@ -1,0 +1,19 @@
+@article{sansone_2017,
+ author = {Sansone, Susanna-Assunta and Gonzalez-Beltran, Alejandra
+and Rocca-Serra, Philippe and Alter, George and Grethe,
+Jeffrey S. and Xu, Hua and Fore, Ian M. and Lyle, Jared and
+Gururaj, Anupama E. and Chen, Xiaoling and Kim, Hyeon-eui
+and Zong, Nansu and Li, Yueling and Liu, Ruiling and
+Ozyurt, I. Burak and Ohno-Machado, Lucila},
+ doi = {10.1038/sdata.2017.59},
+ issn = {2052-4463},
+ journal = {Scientific Data},
+ month = {June},
+ number = {1},
+ publisher = {Springer Science and Business Media LLC},
+ title = {DATS, the data tag suite to enable discoverability of
+datasets},
+ url = {http://dx.doi.org/10.1038/sdata.2017.59},
+ volume = {4},
+ year = {2017}
+}

--- a/content/publications/sansone-2017/index.md
+++ b/content/publications/sansone-2017/index.md
@@ -1,0 +1,29 @@
+---
+title: DATS, the data tag suite to enable discoverability of datasets
+authors:
+- Susanna-Assunta Sansone
+- Alejandra Gonzalez-Beltran
+- Philippe Rocca-Serra
+- George Alter
+- Jeffrey S. Grethe
+- Hua Xu
+- Ian M. Fore
+- Jared Lyle
+- Anupama E. Gururaj
+- Xiaoling Chen
+- Hyeon-eui Kim
+- Nansu Zong
+- Yueling Li
+- Ruiling Liu
+- I. Burak Ozyurt
+- Lucila Ohno-Machado
+date: '2017-06-01'
+publishDate: '2024-12-19T23:16:36.719994Z'
+publication_types:
+- article-journal
+publication: '*Scientific Data*'
+doi: 10.1038/sdata.2017.59
+links:
+- name: URL
+  url: http://dx.doi.org/10.1038/sdata.2017.59
+---

--- a/content/publications/satz-2022/cite.bib
+++ b/content/publications/satz-2022/cite.bib
@@ -1,0 +1,17 @@
+@article{satz_2022,
+ author = {Satz, Skye and Halchenko, Yaroslav O. and Ragozzino,
+Rachel and Lucero, Mora M. and Phillips, Mary L. and
+Swartz, Holly A. and Manelis, Anna},
+ doi = {10.3389/fnhum.2022.749767},
+ issn = {1662-5161},
+ journal = {Frontiers in Human Neuroscience},
+ month = {February},
+ publisher = {Frontiers Media SA},
+ title = {The Relationship Between Default Mode and Dorsal Attention
+Networks Is Associated With Depressive Disorder Diagnosis
+and the Strength of Memory Representations Acquired Prior
+to the Resting State Scan},
+ url = {http://dx.doi.org/10.3389/fnhum.2022.749767},
+ volume = {16},
+ year = {2022}
+}

--- a/content/publications/satz-2022/index.md
+++ b/content/publications/satz-2022/index.md
@@ -1,0 +1,22 @@
+---
+title: The Relationship Between Default Mode and Dorsal Attention Networks Is Associated
+  With Depressive Disorder Diagnosis and the Strength of Memory Representations Acquired
+  Prior to the Resting State Scan
+authors:
+- Skye Satz
+- Yaroslav O. Halchenko
+- Rachel Ragozzino
+- Mora M. Lucero
+- Mary L. Phillips
+- Holly A. Swartz
+- Anna Manelis
+date: '2022-02-01'
+publishDate: '2024-12-19T23:16:36.724149Z'
+publication_types:
+- article-journal
+publication: '*Frontiers in Human Neuroscience*'
+doi: 10.3389/fnhum.2022.749767
+links:
+- name: URL
+  url: http://dx.doi.org/10.3389/fnhum.2022.749767
+---

--- a/content/publications/siless-2020/cite.bib
+++ b/content/publications/siless-2020/cite.bib
@@ -1,0 +1,22 @@
+@article{siless_2020,
+ author = {Siless, Viviana and Hubbard, Nicholas A. and Jones, Robert
+and Wang, Jonathan and Lo, Nicole and Bauer, Clemens C.C.
+and Goncalves, Mathias and Frosch, Isabelle and Norton,
+Daniel and Vergara, Genesis and Conroy, Kristina and De
+Souza, Flavia Vaz and Rosso, Isabelle M. and Wickham,
+Aleena Hay and Cosby, Elizabeth Ann and Pinaire, Megan and
+Hirshfeld-Becker, Dina and Pizzagalli, Diego A. and Henin,
+Aude and Hofmann, Stefan G. and Auerbach, Randy P. and
+Ghosh, Satrajit and Gabrieli, John and Whitfield-Gabrieli,
+Susan and Yendiki, Anastasia},
+ doi = {10.1016/j.nicl.2020.102242},
+ issn = {2213-1582},
+ journal = {NeuroImage: Clinical},
+ pages = {102242},
+ publisher = {Elsevier BV},
+ title = {Image acquisition and quality assurance in the Boston
+Adolescent Neuroimaging of Depression and Anxiety study},
+ url = {http://dx.doi.org/10.1016/j.nicl.2020.102242},
+ volume = {26},
+ year = {2020}
+}

--- a/content/publications/siless-2020/index.md
+++ b/content/publications/siless-2020/index.md
@@ -1,0 +1,39 @@
+---
+title: Image acquisition and quality assurance in the Boston Adolescent Neuroimaging
+  of Depression and Anxiety study
+authors:
+- Viviana Siless
+- Nicholas A. Hubbard
+- Robert Jones
+- Jonathan Wang
+- Nicole Lo
+- Clemens C.C. Bauer
+- Mathias Goncalves
+- Isabelle Frosch
+- Daniel Norton
+- Genesis Vergara
+- Kristina Conroy
+- Flavia Vaz De Souza
+- Isabelle M. Rosso
+- Aleena Hay Wickham
+- Elizabeth Ann Cosby
+- Megan Pinaire
+- Dina Hirshfeld-Becker
+- Diego A. Pizzagalli
+- Aude Henin
+- Stefan G. Hofmann
+- Randy P. Auerbach
+- Satrajit Ghosh
+- John Gabrieli
+- Susan Whitfield-Gabrieli
+- Anastasia Yendiki
+date: '2020-01-01'
+publishDate: '2024-12-19T23:16:36.728104Z'
+publication_types:
+- article-journal
+publication: '*NeuroImage: Clinical*'
+doi: 10.1016/j.nicl.2020.102242
+links:
+- name: URL
+  url: http://dx.doi.org/10.1016/j.nicl.2020.102242
+---

--- a/content/publications/sitek-2019/cite.bib
+++ b/content/publications/sitek-2019/cite.bib
@@ -1,0 +1,16 @@
+@article{sitek_2019,
+ author = {Sitek, Kevin R and Gulban, Omer Faruk and Calabrese, Evan
+and Johnson, G Allan and Lage-Castellanos, Agustin and
+Moerel, Michelle and Ghosh, Satrajit S and De Martino,
+Federico},
+ doi = {10.7554/elife.48932},
+ issn = {2050-084X},
+ journal = {eLife},
+ month = {August},
+ publisher = {eLife Sciences Publications, Ltd},
+ title = {Mapping the human subcortical auditory system using
+histology, postmortem MRI and in vivo MRI at 7T},
+ url = {http://dx.doi.org/10.7554/elife.48932},
+ volume = {8},
+ year = {2019}
+}

--- a/content/publications/sitek-2019/index.md
+++ b/content/publications/sitek-2019/index.md
@@ -1,0 +1,22 @@
+---
+title: Mapping the human subcortical auditory system using histology, postmortem MRI
+  and in vivo MRI at 7T
+authors:
+- Kevin R Sitek
+- Omer Faruk Gulban
+- Evan Calabrese
+- G Allan Johnson
+- Agustin Lage-Castellanos
+- Michelle Moerel
+- Satrajit S Ghosh
+- Federico De Martino
+date: '2019-08-01'
+publishDate: '2024-12-19T23:16:36.732376Z'
+publication_types:
+- article-journal
+publication: '*eLife*'
+doi: 10.7554/elife.48932
+links:
+- name: URL
+  url: http://dx.doi.org/10.7554/elife.48932
+---

--- a/content/publications/soko-owski-2024/cite.bib
+++ b/content/publications/soko-owski-2024/cite.bib
@@ -1,0 +1,20 @@
+@article{soko_owski_2024,
+ author = {Sokołowski, Andrzej and Bhagwat, Nikhil and Chatelain,
+Yohan and Dugré, Mathieu and Hanganu, Alexandru and
+Monchi, Oury and McPherson, Brent and Wang, Michelle and
+Poline, Jean-Baptiste and Sharp, Madeleine and Glatard,
+Tristan},
+ doi = {10.1371/journal.pone.0295069},
+ editor = {Bergsland, Niels},
+ issn = {1932-6203},
+ journal = {PLOS ONE},
+ month = {January},
+ number = {1},
+ pages = {e0295069},
+ publisher = {Public Library of Science (PLoS)},
+ title = {Longitudinal brain structure changes in Parkinson’s
+disease: A replication study},
+ url = {http://dx.doi.org/10.1371/journal.pone.0295069},
+ volume = {19},
+ year = {2024}
+}

--- a/content/publications/soko-owski-2024/index.md
+++ b/content/publications/soko-owski-2024/index.md
@@ -1,0 +1,25 @@
+---
+title: 'Longitudinal brain structure changes in Parkinson’s disease: A replication
+  study'
+authors:
+- Andrzej Sokołowski
+- Nikhil Bhagwat
+- Yohan Chatelain
+- Mathieu Dugré
+- Alexandru Hanganu
+- Oury Monchi
+- Brent McPherson
+- Michelle Wang
+- Jean-Baptiste Poline
+- Madeleine Sharp
+- Tristan Glatard
+date: '2024-01-01'
+publishDate: '2024-12-19T23:16:36.736403Z'
+publication_types:
+- article-journal
+publication: '*PLOS ONE*'
+doi: 10.1371/journal.pone.0295069
+links:
+- name: URL
+  url: http://dx.doi.org/10.1371/journal.pone.0295069
+---

--- a/content/publications/solo-2018/cite.bib
+++ b/content/publications/solo-2018/cite.bib
@@ -1,0 +1,16 @@
+@article{solo_2018,
+ author = {Solo, Victor and Poline, Jean-Baptiste and Lindquist,
+Martin A. and Simpson, Sean L. and Bowman, F. DuBois and
+Chung, Moo K. and Cassidy, Ben},
+ doi = {10.1109/tmi.2018.2831261},
+ issn = {1558-254X},
+ journal = {IEEE Transactions on Medical Imaging},
+ month = {July},
+ number = {7},
+ pages = {1537–1550},
+ publisher = {Institute of Electrical and Electronics Engineers (IEEE)},
+ title = {Connectivity in fMRI: Blind Spots and Breakthroughs},
+ url = {http://dx.doi.org/10.1109/tmi.2018.2831261},
+ volume = {37},
+ year = {2018}
+}

--- a/content/publications/solo-2018/index.md
+++ b/content/publications/solo-2018/index.md
@@ -1,0 +1,20 @@
+---
+title: 'Connectivity in fMRI: Blind Spots and Breakthroughs'
+authors:
+- Victor Solo
+- Jean-Baptiste Poline
+- Martin A. Lindquist
+- Sean L. Simpson
+- F. DuBois Bowman
+- Moo K. Chung
+- Ben Cassidy
+date: '2018-07-01'
+publishDate: '2024-12-19T23:16:36.740512Z'
+publication_types:
+- article-journal
+publication: '*IEEE Transactions on Medical Imaging*'
+doi: 10.1109/tmi.2018.2831261
+links:
+- name: URL
+  url: http://dx.doi.org/10.1109/tmi.2018.2831261
+---

--- a/content/publications/szczepanik-2024/cite.bib
+++ b/content/publications/szczepanik-2024/cite.bib
@@ -1,0 +1,17 @@
+@article{szczepanik_2024,
+ author = {Szczepanik, Michał and Wagner, Adina S. and Heunis,
+Stephan and Waite, Laura K. and Eickhoff, Simon B. and
+Hanke, Michael},
+ doi = {10.1007/s12021-024-09665-7},
+ issn = {1559-0089},
+ journal = {Neuroinformatics},
+ month = {May},
+ number = {4},
+ pages = {635–645},
+ publisher = {Springer Science and Business Media LLC},
+ title = {Teaching Research Data Management with DataLad: A
+Multi-year, Multi-domain Effort},
+ url = {http://dx.doi.org/10.1007/s12021-024-09665-7},
+ volume = {22},
+ year = {2024}
+}

--- a/content/publications/szczepanik-2024/index.md
+++ b/content/publications/szczepanik-2024/index.md
@@ -1,0 +1,20 @@
+---
+title: 'Teaching Research Data Management with DataLad: A Multi-year, Multi-domain
+  Effort'
+authors:
+- Michał Szczepanik
+- Adina S. Wagner
+- Stephan Heunis
+- Laura K. Waite
+- Simon B. Eickhoff
+- Michael Hanke
+date: '2024-05-01'
+publishDate: '2024-12-19T23:16:36.744635Z'
+publication_types:
+- article-journal
+publication: '*Neuroinformatics*'
+doi: 10.1007/s12021-024-09665-7
+links:
+- name: URL
+  url: http://dx.doi.org/10.1007/s12021-024-09665-7
+---

--- a/content/publications/torabi-2024/cite.bib
+++ b/content/publications/torabi-2024/cite.bib
@@ -1,0 +1,13 @@
+@article{torabi_2024,
+ author = {Torabi, Mohammad and Mitsis, Georgios D and Poline,
+Jean-Baptiste},
+ doi = {10.1093/gigascience/giae009},
+ issn = {2047-217X},
+ journal = {GigaScience},
+ publisher = {Oxford University Press (OUP)},
+ title = {On the variability of dynamic functional connectivity
+assessment methods},
+ url = {http://dx.doi.org/10.1093/gigascience/giae009},
+ volume = {13},
+ year = {2024}
+}

--- a/content/publications/torabi-2024/index.md
+++ b/content/publications/torabi-2024/index.md
@@ -1,0 +1,16 @@
+---
+title: On the variability of dynamic functional connectivity assessment methods
+authors:
+- Mohammad Torabi
+- Georgios D Mitsis
+- Jean-Baptiste Poline
+date: '2024-01-01'
+publishDate: '2024-12-19T23:16:36.748621Z'
+publication_types:
+- article-journal
+publication: '*GigaScience*'
+doi: 10.1093/gigascience/giae009
+links:
+- name: URL
+  url: http://dx.doi.org/10.1093/gigascience/giae009
+---

--- a/content/publications/torabian-2023/cite.bib
+++ b/content/publications/torabian-2023/cite.bib
@@ -1,0 +1,14 @@
+@article{torabian_2023,
+ author = {Torabian, Sajjad and Vélez, Natalia and Sochat, Vanessa
+and Halchenko, Yaroslav O. and Grossman, Emily D.},
+ doi = {10.3389/fnins.2023.1233416},
+ issn = {1662-453X},
+ journal = {Frontiers in Neuroscience},
+ month = {August},
+ publisher = {Frontiers Media SA},
+ title = {The PyMVPA BIDS-App: a robust multivariate pattern
+analysis pipeline for fMRI data},
+ url = {http://dx.doi.org/10.3389/fnins.2023.1233416},
+ volume = {17},
+ year = {2023}
+}

--- a/content/publications/torabian-2023/index.md
+++ b/content/publications/torabian-2023/index.md
@@ -1,0 +1,19 @@
+---
+title: 'The PyMVPA BIDS-App: a robust multivariate pattern analysis pipeline for fMRI
+  data'
+authors:
+- Sajjad Torabian
+- Natalia Vélez
+- Vanessa Sochat
+- Yaroslav O. Halchenko
+- Emily D. Grossman
+date: '2023-08-01'
+publishDate: '2024-12-19T23:16:36.752491Z'
+publication_types:
+- article-journal
+publication: '*Frontiers in Neuroscience*'
+doi: 10.3389/fnins.2023.1233416
+links:
+- name: URL
+  url: http://dx.doi.org/10.3389/fnins.2023.1233416
+---

--- a/content/publications/torres-esp-n-2021/cite.bib
+++ b/content/publications/torres-esp-n-2021/cite.bib
@@ -1,0 +1,31 @@
+@article{torres_esp_n_2021,
+ author = {Torres-Espín, Abel and Almeida, Carlos A. and Chou,
+Austin and Huie, J. Russell and Chiu, Michael and Vavrek,
+Romana and Sacramento, Jeff and Orr, Michael B. and Gensel,
+John C. and Grethe, Jeffery S. and Martone, Maryann E. and
+Fouad, Karim and Ferguson, Adam R. and Alilain, Warren and
+Bacon, Mark and Batty, Nicholas and Beattie, Michael and
+Bresnahan, Jacqueline and Burnside, Emily and Busch, Sarah
+and Carpenter, Randall and Quijorna, Isaac Francos and Guo,
+Xiaohui and Haggerty, Agnes and Haroon, Sarah and Harris,
+Jack and Jakeman, Lyn and Jones, Linda and Kleitman, Naomi
+and Kopper, Timothy and Lane, Michael and Magana, Francisco
+and Magnuson, David and Maldonado, Ines and May, Verena and
+McFarlane, Katelyn and Morioka, Kazuhito and Oudega, Martin
+and Pascual, Philip Leo and Poline, Jean-Baptiste and
+Rosenzweig, Ephron and Schmidt, Emma and Tetzlaff, Wolfram
+and Zholudeva, Lana},
+ doi = {10.1007/s12021-021-09533-8},
+ issn = {1559-0089},
+ journal = {Neuroinformatics},
+ month = {August},
+ number = {1},
+ pages = {203–219},
+ publisher = {Springer Science and Business Media LLC},
+ title = {Promoting FAIR Data Through Community-driven Agile Design:
+the Open Data Commons for Spinal Cord Injury
+(odc-sci.org)},
+ url = {http://dx.doi.org/10.1007/s12021-021-09533-8},
+ volume = {20},
+ year = {2021}
+}

--- a/content/publications/torres-esp-n-2021/index.md
+++ b/content/publications/torres-esp-n-2021/index.md
@@ -1,0 +1,58 @@
+---
+title: 'Promoting FAIR Data Through Community-driven Agile Design: the Open Data Commons
+  for Spinal Cord Injury (odc-sci.org)'
+authors:
+- Abel Torres-Espín
+- Carlos A. Almeida
+- Austin Chou
+- J. Russell Huie
+- Michael Chiu
+- Romana Vavrek
+- Jeff Sacramento
+- Michael B. Orr
+- John C. Gensel
+- Jeffery S. Grethe
+- Maryann E. Martone
+- Karim Fouad
+- Adam R. Ferguson
+- Warren Alilain
+- Mark Bacon
+- Nicholas Batty
+- Michael Beattie
+- Jacqueline Bresnahan
+- Emily Burnside
+- Sarah Busch
+- Randall Carpenter
+- Isaac Francos Quijorna
+- Xiaohui Guo
+- Agnes Haggerty
+- Sarah Haroon
+- Jack Harris
+- Lyn Jakeman
+- Linda Jones
+- Naomi Kleitman
+- Timothy Kopper
+- Michael Lane
+- Francisco Magana
+- David Magnuson
+- Ines Maldonado
+- Verena May
+- Katelyn McFarlane
+- Kazuhito Morioka
+- Martin Oudega
+- Philip Leo Pascual
+- Jean-Baptiste Poline
+- Ephron Rosenzweig
+- Emma Schmidt
+- Wolfram Tetzlaff
+- Lana Zholudeva
+date: '2021-08-01'
+publishDate: '2024-12-19T23:16:36.756484Z'
+publication_types:
+- article-journal
+publication: '*Neuroinformatics*'
+doi: 10.1007/s12021-021-09533-8
+links:
+- name: URL
+  url: http://dx.doi.org/10.1007/s12021-021-09533-8
+---

--- a/content/publications/wang-2023/cite.bib
+++ b/content/publications/wang-2023/cite.bib
@@ -1,0 +1,18 @@
+@article{wang_2023,
+ author = {Wang, Qing and Aljassar, Meshal and Bhagwat, Nikhil and
+Zeighami, Yashar and Evans, Alan C. and Dagher, Alain and
+Pike, G. Bruce and Sadikot, Abbas F. and Poline,
+Jean-Baptiste},
+ doi = {10.1038/s41598-022-25306-y},
+ issn = {2045-2322},
+ journal = {Scientific Reports},
+ month = {January},
+ number = {1},
+ publisher = {Springer Science and Business Media LLC},
+ title = {Reproducibility of cerebellar involvement as quantified by
+consensus structural MRI biomarkers in advanced essential
+tremor},
+ url = {http://dx.doi.org/10.1038/s41598-022-25306-y},
+ volume = {13},
+ year = {2023}
+}

--- a/content/publications/wang-2023/index.md
+++ b/content/publications/wang-2023/index.md
@@ -1,0 +1,23 @@
+---
+title: Reproducibility of cerebellar involvement as quantified by consensus structural
+  MRI biomarkers in advanced essential tremor
+authors:
+- Qing Wang
+- Meshal Aljassar
+- Nikhil Bhagwat
+- Yashar Zeighami
+- Alan C. Evans
+- Alain Dagher
+- G. Bruce Pike
+- Abbas F. Sadikot
+- Jean-Baptiste Poline
+date: '2023-01-01'
+publishDate: '2024-12-19T23:16:36.761207Z'
+publication_types:
+- article-journal
+publication: '*Scientific Reports*'
+doi: 10.1038/s41598-022-25306-y
+links:
+- name: URL
+  url: http://dx.doi.org/10.1038/s41598-022-25306-y
+---

--- a/content/publications/wimalaratne-2018/cite.bib
+++ b/content/publications/wimalaratne-2018/cite.bib
@@ -1,0 +1,17 @@
+@article{wimalaratne_2018,
+ author = {Wimalaratne, Sarala M. and Juty, Nick and Kunze, John and
+Janée, Greg and McMurry, Julie A. and Beard, Niall and
+Jimenez, Rafael and Grethe, Jeffrey S. and Hermjakob,
+Henning and Martone, Maryann E. and Clark, Tim},
+ doi = {10.1038/sdata.2018.29},
+ issn = {2052-4463},
+ journal = {Scientific Data},
+ month = {May},
+ number = {1},
+ publisher = {Springer Science and Business Media LLC},
+ title = {Uniform resolution of compact identifiers for biomedical
+data},
+ url = {http://dx.doi.org/10.1038/sdata.2018.29},
+ volume = {5},
+ year = {2018}
+}

--- a/content/publications/wimalaratne-2018/index.md
+++ b/content/publications/wimalaratne-2018/index.md
@@ -1,0 +1,24 @@
+---
+title: Uniform resolution of compact identifiers for biomedical data
+authors:
+- Sarala M. Wimalaratne
+- Nick Juty
+- John Kunze
+- Greg Janée
+- Julie A. McMurry
+- Niall Beard
+- Rafael Jimenez
+- Jeffrey S. Grethe
+- Henning Hermjakob
+- Maryann E. Martone
+- Tim Clark
+date: '2018-05-01'
+publishDate: '2024-12-19T23:16:36.765210Z'
+publication_types:
+- article-journal
+publication: '*Scientific Data*'
+doi: 10.1038/sdata.2018.29
+links:
+- name: URL
+  url: http://dx.doi.org/10.1038/sdata.2018.29
+---

--- a/content/publications/yarkoni-2019/cite.bib
+++ b/content/publications/yarkoni-2019/cite.bib
@@ -1,0 +1,25 @@
+@article{yarkoni_2019,
+ author = {Yarkoni, Tal and Markiewicz, Christopher and de la Vega,
+Alejandro and Gorgolewski, Krzysztof and Salo, Taylor and
+Halchenko, Yaroslav and McNamara, Quinten and DeStasio,
+Krista and Poline, Jean-Baptiste and Petrov, Dmitry and
+Hayot-Sasson, Valérie and Nielson, Dylan and Carlin, Johan
+and Kiar, Gregory and Whitaker, Kirstie and DuPre,
+Elizabeth and Wagner, Adina and Tirrell, Lee and Jas,
+Mainak and Hanke, Michael and Poldrack, Russell and
+Esteban, Oscar and Appelhoff, Stefan and Holdgraf, Chris
+and Staden, Isla and Thirion, Bertrand and Kleinschmidt,
+Dave and Lee, John and di Castello, Matteo and Notter,
+Michael and Blair, Ross},
+ doi = {10.21105/joss.01294},
+ issn = {2475-9066},
+ journal = {Journal of Open Source Software},
+ month = {August},
+ number = {40},
+ pages = {1294},
+ publisher = {The Open Journal},
+ title = {PyBIDS: Python tools for BIDS datasets},
+ url = {http://dx.doi.org/10.21105/joss.01294},
+ volume = {4},
+ year = {2019}
+}

--- a/content/publications/yarkoni-2019/index.md
+++ b/content/publications/yarkoni-2019/index.md
@@ -1,0 +1,44 @@
+---
+title: 'PyBIDS: Python tools for BIDS datasets'
+authors:
+- Tal Yarkoni
+- Christopher Markiewicz
+- Alejandro de la Vega
+- Krzysztof Gorgolewski
+- Taylor Salo
+- Yaroslav Halchenko
+- Quinten McNamara
+- Krista DeStasio
+- Jean-Baptiste Poline
+- Dmitry Petrov
+- Valérie Hayot-Sasson
+- Dylan Nielson
+- Johan Carlin
+- Gregory Kiar
+- Kirstie Whitaker
+- Elizabeth DuPre
+- Adina Wagner
+- Lee Tirrell
+- Mainak Jas
+- Michael Hanke
+- Russell Poldrack
+- Oscar Esteban
+- Stefan Appelhoff
+- Chris Holdgraf
+- Isla Staden
+- Bertrand Thirion
+- Dave Kleinschmidt
+- John Lee
+- Matteo di Castello
+- Michael Notter
+- Ross Blair
+date: '2019-08-01'
+publishDate: '2024-12-19T23:16:36.769287Z'
+publication_types:
+- article-journal
+publication: '*Journal of Open Source Software*'
+doi: 10.21105/joss.01294
+links:
+- name: URL
+  url: http://dx.doi.org/10.21105/joss.01294
+---

--- a/content/publications/zhao-2023/cite.bib
+++ b/content/publications/zhao-2023/cite.bib
@@ -1,0 +1,18 @@
+@article{zhao_2023,
+ author = {Zhao, Chenying and Jarecka, Dorota and Covitz, Sydney and
+Chen, Yibei and Eickhoff, Simon B. and Fair, Damien A. and
+Franco, Alexandre R. and Halchenko, Yaroslav O. and
+Hendrickson, Timothy J. and Hoffstaedter, Felix and
+Houghton, Audrey and Kiar, Gregory and Macdonald, Austin
+and Mehta, Kahini and Milham, Michael P. and Salo, Taylor
+and Hanke, Michael and Ghosh, Satrajit S. and Cieslak,
+Matthew and Satterthwaite, Theodore D.},
+ doi = {10.1101/2023.08.16.552472},
+ month = {August},
+ publisher = {Cold Spring Harbor Laboratory},
+ title = {A reproducible and generalizable software workflow for
+analysis of large-scale neuroimaging data collections using
+BIDS Apps},
+ url = {http://dx.doi.org/10.1101/2023.08.16.552472},
+ year = {2023}
+}

--- a/content/publications/zhao-2023/index.md
+++ b/content/publications/zhao-2023/index.md
@@ -1,0 +1,34 @@
+---
+title: A reproducible and generalizable software workflow for analysis of large-scale
+  neuroimaging data collections using BIDS Apps
+authors:
+- Chenying Zhao
+- Dorota Jarecka
+- Sydney Covitz
+- Yibei Chen
+- Simon B. Eickhoff
+- Damien A. Fair
+- Alexandre R. Franco
+- Yaroslav O. Halchenko
+- Timothy J. Hendrickson
+- Felix Hoffstaedter
+- Audrey Houghton
+- Gregory Kiar
+- Austin Macdonald
+- Kahini Mehta
+- Michael P. Milham
+- Taylor Salo
+- Michael Hanke
+- Satrajit S. Ghosh
+- Matthew Cieslak
+- Theodore D. Satterthwaite
+date: '2023-08-01'
+publishDate: '2024-12-19T23:16:36.773770Z'
+publication_types:
+- article-journal
+publication: '*Cold Spring Harbor Laboratory*'
+doi: 10.1101/2023.08.16.552472
+links:
+- name: URL
+  url: http://dx.doi.org/10.1101/2023.08.16.552472
+---

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -66,3 +66,7 @@ deployment:
     targets:
         name: public
         URL: s3://dev.repronim.org
+
+taxonomies:
+  author: authors
+

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -69,4 +69,5 @@ deployment:
 
 taxonomies:
   author: authors
+  publication: publications
 

--- a/layouts/publications/single.html
+++ b/layouts/publications/single.html
@@ -1,0 +1,15 @@
+{{ define "main" }}
+  <article>
+    <h1>{{ .Title }}</h1>
+    <p>By:
+      {{ range $index, $author := .Params.authors }}
+        {{ if $index }}, {{ end }}
+        <a href="{{ "/authors/" | relURL }}{{ $author | urlize }}">{{ $author }}</a>
+      {{ end }}
+    </p>
+    <p>{{ .Date.Format "January 2, 2006" }}</p>
+    <div>
+      {{ .Content }}
+    </div>
+  </article>
+{{ end }}

--- a/tools/import_doi
+++ b/tools/import_doi
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# Provide DOIs to import
+#
+# Uses "academic" (pip install academic) and bibtool (apt install bibtool)
+
+set -eu
+
+topd=$(dirname "$0")/..
+pubdir="$topd/content/publications"
+bibs="$pubdir/publications.bib"
+
+
+echo "Storing BibTeX records into $bibs"
+for arg in "$@"; do
+    doi=$(echo "$arg" | sed -e 's,https*://.*doi\.org/,,g')
+    if grep -q "$doi" "$bibs" 2>/dev/null; then
+        echo "DOI $doi already known to $bibs. skipping"
+        continue
+    fi
+    mkdir -p "$pubdir"
+    touch "$bibs"
+    if ! curl --silent -L -d "" --header "Accept: application/x-bibtex; charset=utf-8" https://doi.org/$doi | sed -e 's,%2F,/,g' >> "$bibs"; then
+        echo "ERROR: failed to fetch bibtex for doi $doi"
+        exit 1
+    fi
+done
+
+bibtool -s -i "$bibs" -o "$bibs"
+
+if [ -e "$bibs" ]; then
+    echo "Importing"
+    academic import --compact "$bibs" "$pubdir"
+    git status "$pubdir"
+else
+    echo "No $bibs, nothing todo"
+fi

--- a/tools/import_doi_all
+++ b/tools/import_doi_all
@@ -1,0 +1,10 @@
+#!/bin/bash
+#
+# one time use script to import all already existing in plain text publications
+#
+
+#
+# TODO: ideally for all THOSE added entries we should add a tag "repronim" or alike so we could
+# add also related publications and then separate from those which are associated directly with ReproNim
+# 
+grep 'doi:' content/about/publications.md | sed -e 's,.*(https://doi.org/\(.*\)).*,\1,g' | xargs tools/import_doi


### PR DESCRIPTION
I added `tools/import-doi*` scripts which I used to import all listed publications into their dedicated files which would then provide linkage to "author"s, for which some of them would be us and we could enhance their pages.

Overall goal would be to arrive at something like  the found  "hugo-blox" based theme https://github.com/HugoBlox/theme-research-group , with demo at https://research-group.netlify.app/ . 

I think it kinda fits the needed elements well.  Check out how it is actually defining those entries, e.g. https://research-group.netlify.app/author/nelson-bighetti/ is produced from this yaml: https://raw.githubusercontent.com/HugoBlox/theme-research-group/refs/heads/main/content/authors/admin/_index.md and due to use of the [hugo taxonomies](https://gohugo.io/content-management/taxonomies/) allows to link together relevant content "automagically". So it couples e.g. with the list of publications: https://research-group.netlify.app/publication/ which could be imported from DOI/BibTex using  the smae https://github.com/GetRD/academic-file-converter/ I used here to convert fetched DOIs into publication records.