### PR TITLE
Check external links

### DIFF
--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -41,4 +41,4 @@ jobs:
 
       - name: Check links
         run: |
-          linkchecker --check-extern -f .linkcheckerrc http://localhost:1313
+          linkchecker --check-extern -f .linkcheckerrc http://localhost:1313 --no-status --no-warnings

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -13,6 +13,10 @@ jobs:
           # If your Hugo theme is a submodule, this ensures it gets pulled
           submodules: true
 
+      - name: Install linkchecker
+        run: |
+          pip install linkchecker
+
       - name: Read hugo version
         id: hugo-version
         run: |
@@ -26,17 +30,15 @@ jobs:
           hugo-version: '${{ steps.hugo-version.outputs.HUGO_VERSION }}'
 
       - name: Build site
-        run: hugo
-
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.3.6'
-      - name: Create Gemfile and install dependencies
         run: |
-          echo "source 'https://rubygems.org'" > Gemfile
-          echo "gem 'html-proofer', '5.0.9'" >> Gemfile
-          bundle install
+          hugo
+          # linkchecker will skip if we do not remove robots tags
+          sed -i '/<meta name="robots"/d' public/**/*.html
+          cd public
+          # Simple server not hugo so autoreload does not confuse linkchecker
+          python3 -m http.server 1313 &
+          sleep 1
 
-      - name: Run html-proofer
-        run: htmlproofer ./public --disable-external --no-enforce-https
+      - name: Check links
+        run: |
+          linkchecker --check-extern -f .linkcheckerrc http://localhost:1313

--- a/.linkcheckerrc
+++ b/.linkcheckerrc
@@ -25,6 +25,7 @@ ignore =
   ^https://doi\.org/10\.1159/000530358
   ^https://doi\.org/10\.1162/imag_a_00074
   ^https://doi\.org/10\.1162/imag_a_00103
+  ^https://doi\.org/10\.12688/f1000research\.25306\.2
   ^https://doi\.org/10\.12688/mniopenres\.12772\.2
   ^https://doi\.org/10\.3233/jpd-191775
   ^https://elixiruknode\.org/

--- a/.linkcheckerrc
+++ b/.linkcheckerrc
@@ -21,6 +21,7 @@ ignore =
   ^https://doi\.org/10\.1101/2023\.08\.01\.551505
   ^https://doi\.org/10\.1101/2023\.08\.16\.552472
   ^https://doi\.org/10\.1109/tmi\.2018\.2831261
+  ^https://doi\.org/10\.1146/annurev-neuro-100119-110036
   ^https://doi\.org/10\.1148/radiol\.210385
   ^https://doi\.org/10\.1159/000530358
   ^https://doi\.org/10\.1162/imag_a_00074

--- a/.linkcheckerrc
+++ b/.linkcheckerrc
@@ -1,0 +1,49 @@
+[checking]
+sslverify=0
+
+[filtering]
+ignore =
+  # Sites which do not resolve for link checker (prohibited bots etc) hand-checked prior to being ignored
+  ^https://abcdstudy\.org/about/
+  ^https://childmind\.org/bio/michael-p-milham-md-phd/
+  ^https://coinstac\.org/
+  ^https://doi\.org/10\.1002/hbm\.25351
+  ^https://doi\.org/10\.1002/lio2\.354
+  ^https://doi\.org/10\.1073/pnas\.1608282113
+  ^https://doi\.org/10\.1093/cercor/bhx030
+  ^https://doi\.org/10\.1093/database/bay130
+  ^https://doi\.org/10\.1093/gerona/glw236
+  ^https://doi\.org/10\.1093/gigascience/giaa155
+  ^https://doi\.org/10\.1093/gigascience/giab055
+  ^https://doi\.org/10\.1093/gigascience/giac013
+  ^https://doi\.org/10\.1093/gigascience/giae009
+  ^https://doi\.org/10\.1093/gigascience/giy077
+  ^https://doi\.org/10\.1101/2023\.08\.01\.551505
+  ^https://doi\.org/10\.1101/2023\.08\.16\.552472
+  ^https://doi\.org/10\.1109/tmi\.2018\.2831261
+  ^https://doi\.org/10\.1148/radiol\.210385
+  ^https://doi\.org/10\.1159/000530358
+  ^https://doi\.org/10\.1162/imag_a_00074
+  ^https://doi\.org/10\.1162/imag_a_00103
+  ^https://doi\.org/10\.12688/mniopenres\.12772\.2
+  ^https://doi\.org/10\.3233/jpd-191775
+  ^https://elixiruknode\.org/
+  ^https://git-scm\.com/downloads
+  ^https://git-scm\.com/
+  ^https://grants\.nih\.gov/grants-process/write-application/forms-directory/data-management-and-sharing-plan-format-page
+  ^https://keck\.usc\.edu/faculty-search/paul-m-thompson/
+  ^https://midb\.umn\.edu/staff/damien-fair
+  # nsg uses legacy ssl handshake
+  ^https://www\.nsgportal\.org/overview\.html
+  ^https://pbs\.dartmouth\.edu/people/yaroslav-o-halchenko-0
+  ^https://sharing\.nih\.gov/data-management-and-sharing-policy/planning-and-budgeting-for-data-management-and-sharing/budgeting-for-data-management-sharing#after
+  ^https://sharing\.nih\.gov/data-management-and-sharing-policy/planning-and-budgeting-for-data-management-and-sharing/writing-a-data-management-and-sharing-plan#after
+  ^https://trendscenter\.org/jessica-turner/
+  ^https://www\.macfound\.org/fellows/class-of-2020/damien-fair
+  ^https://www\.mir\.wustl\.edu/employees/daniel-marcus/
+  ^https://www\.mir\.wustl\.edu/employees/janine-bijsterbosch/
+  ^https://www\.umassmed\.edu/news/news-archives/2022/02/david-kennedy-awarded-$6-million-repronim-brain-imaging-grant
+
+[output]
+ignoreerrors=
+  ^mailto:.*$

--- a/content/about/team.md
+++ b/content/about/team.md
@@ -30,7 +30,7 @@ weight: 10
     - Adjunct Associate Professor of Computer Science, Dartmouth College, Hanover, NH
 - [Jean-Baptise Poline](https://www.mcgill.ca/neuro/jean-baptiste-poline-phd) Training Core Lead
     - Associate Professor of Neurology and Neurosurgery, Montreal Neurologic Institute, McGill University, Montreal, Canada
-        - Primary Investigator, [Ludmer Centre](http://ludmercentre.ca/dr-jean-baptiste-poline/) for Neuroinformatics & Mental Health, Montreal Neurologic Institute
+        - Primary Investigator, [Ludmer Centre](https://www.mcgill.ca/ludmercentre/our-people/principal-investigators/jb-poline) for Neuroinformatics & Mental Health, Montreal Neurologic Institute
         - Principal Investigator, NeuroDataScience - [ORIGAMI Research Group](https://neurodatascience.github.io/), Montreal Neurologic Institute
     - Chair, CTSI, [INCF](https://www.incf.org/team/prof-jean-baptiste-poline)
 

--- a/content/about/webinars.md
+++ b/content/about/webinars.md
@@ -74,7 +74,7 @@ ReproNim faculty member [Jeffrey Grethe](https://www.linkedin.com/in/jgrethe) (U
 [Video Presentation](https://youtu.be/inKkwjSe4hY) and [Slides](https://drive.google.com/drive/folders/1CS8G1kFg2cdzFb7CYqgJXRcGsptBCya5) are now available.
 
 ### Friday, November 3, 2023
-We welcome [Anisha Keshavan](https://theorg.com/org/octave-bioscience/org-chart/anisha-keshavan), Senior Data Scientist from Octave Bioscience, for a discussion of 'Reproducible Data Science Practices at Octave.'
+We welcome Anisha Keshavan, Senior Data Scientist from Octave Bioscience, for a discussion of 'Reproducible Data Science Practices at Octave.'
 
 [Video Presentation](https://youtu.be/DG6mUZ5XlS4) is now available
 
@@ -88,7 +88,7 @@ We welcome [Anisha Keshavan](https://theorg.com/org/octave-bioscience/org-chart/
 ### Friday, June 2, 2023 at 2pm EDT
 [Arno Klein](https://matter.childmind.org/) is our special guest speaker, joining us from the Child Mind Institute to share some of his intriguing and innovative technological developments aimed at better understanding of and treatment for childhood mental health disorders: [MindLogger platform](https://mindlogger.org/) for configurable data collection and interventions in research and clinical practice
 
-[Video Presentation](https://youtu.be/zCbaCpoyUNo) and [Slides](https://docs.google.com/presentation/d/1uwS9aXBviwukByLsT5RnLnMhrNgqu8CvKDeQ04mlS4E/edit?usp=sharing) are now available.
+[Video Presentation](https://youtu.be/zCbaCpoyUNo) are now available.
 
 ### Friday, May 5, 2023
 We're excited to have [Angie Laird](https://nbclab.github.io/team/laird-angela), from the Neuroinformatics and Brain Connectivity group at Florida International University as our featured guest speaker. Angie shares her wisdom and very experienced perspective with a presentation on "Large, Open Datasets for Neuroimaging Research: Considerations for Reproducible and Responsible Data Use."
@@ -130,7 +130,7 @@ ReproNim Collaborator [Mike Yassa](https://faculty.sites.uci.edu/myassa/), along
 [Video Presentation](https://youtu.be/lYSe76-F9RM) is now available.
 
 ### Friday, October 7, 2022 at 2pm EDT
-We kick off the new academic year with a special presentation by ReproNim faculty member Maryann Martone ([UCSD](https://profiles.ucsd.edu/maryann.martone), [INCF](https://www.incf.org/team/prof-maryann-martone)), Reflections on progress in open and [FAIR](https://www.fdilab.org/team) neuroscience. Maryann discusses the 'hows and whys' for the current sea change in neuroscience towards an an open and FAIR approach to all aspects of research, and the implications and importance of this movement for neuroscience going forward.
+We kick off the new academic year with a special presentation by ReproNim faculty member Maryann Martone ([UCSD](https://profiles.ucsd.edu/maryann.martone), [INCF](https://www.incf.org/cv/maryann-martone)), Reflections on progress in open and [FAIR](https://www.fdilab.org/team) neuroscience. Maryann discusses the 'hows and whys' for the current sea change in neuroscience towards an an open and FAIR approach to all aspects of research, and the implications and importance of this movement for neuroscience going forward.
 
 [Video Presentation](https://youtu.be/hX_JnsZz-uY) is now available.
 
@@ -142,7 +142,7 @@ Special guest speaker [Ted Satterthwaite](https://www.pennlinc.io//team/Ted-Satt
 [Video Presentation](https://www.youtube.com/watch?v=6hgiH7BYKPs) is now available.
 
 ### Friday, May 6, 2022 at 2pm EDT
-We welcome guest speaker [Eugenio Iglesias](https://scholar.harvard.edu/iglesias) from MGH, for a presentation on Synth*: Domain Randomization for out-of-the-box Brain Analysis with Enhanced Reproducibility.
+We welcome guest speaker Eugenio Iglesias from MGH, for a presentation on Synth*: Domain Randomization for out-of-the-box Brain Analysis with Enhanced Reproducibility.
 
 [Video Presentation](https://www.youtube.com/watch?v=ET3Cw1Z-KUw) is now available.
 
@@ -181,7 +181,7 @@ Guest speaker and ReproNim-INCF Fellow [Chris Rorden](https://cstar.sc.edu/chris
 [Slides](https://docs.google.com/presentation/d/1zqGohKBFZrckVOVm1Fvj6ASXeeVoyL9k_PVg13eWcgM/edit#slide=id.gc6f9544c1_0_0) are available.
 
 ### Friday, October 1, 2021 at 2pm EDT
-We kick off our fall schedule with special guest speakers [David Van Essen](http://dbbs.wustl.edu/faculty/Pages/faculty_bio.aspx?SID=1569) and [Matt Glasser](https://neuroscience.wustl.edu/people/matthew-glasser/) on the topic of Reproducibility in Human Neuroimaging: Lessons from the Human Connectome Project.
+We kick off our fall schedule with special guest speakers [David Van Essen](https://profiles.wustl.edu/en/persons/david-van-essen) and [Matt Glasser](https://neuroscience.wustl.edu/people/matthew-glasser/) on the topic of Reproducibility in Human Neuroimaging: Lessons from the Human Connectome Project.
 
 [Video Presentation](https://youtu.be/TBvbneQvIOI) and
 [Slides](https://docs.google.com/presentation/d/1_74sex8RuFiN389hv85Pv0eo-dpNVqCu/edit#slide=id.p1) are available.
@@ -192,7 +192,7 @@ ReproNim collaborators [Michael O'Shea](https://www.med.unc.edu/childrensresearc
 [Video](https://youtu.be/gSI_Do8OIqg) is now available, as are both [Mike O'Shea's Slides](https://drive.google.com/drive/folders/1e-3kNU6vEGm7DKeyDjf3vIKg34C7xoJf) and [David Kennedy's Slides](https://docs.google.com/presentation/d/1NdzNF88y5ZvlXZ5UVY_WSHHxi5pzC32dLNJ0IZRX1So/edit#slide=id.ge348a8c958_0_159)
 
 ### Friday, June 4, 2021 at 2pm EDT
-Guest speaker [Kristina Rapuano](http://fablab.yale.edu/people/kristina-rapuano) joins us from Yale, with a presentation on “Large-scale restriction spectrum imaging and applications to pediatric obesity.”
+Guest speaker Kristina Rapuano joins us from Yale, with a presentation on “Large-scale restriction spectrum imaging and applications to pediatric obesity.”
 
 [Video](https://youtu.be/vC6nJWciAbI) and
 [Slides](https://drive.google.com/drive/folders/1WAXNZiylHsFncLSRRYDQ3HK7EIe7-yLb) are now available.
@@ -263,7 +263,7 @@ Both the [Video Presentation](https://youtu.be/ix3lC6HGo-Q) and
 [Slides](https://docs.google.com/presentation/d/1NvjpsrbDHz_9WivvYICTh2U8Xak8TFk5nyWLiCdrHAU/edit?usp=sharing) are now available
 
 ### Friday, May 1, 2020 at 2pm EDT
-Guest speaker [Franco Pestilli](https://iuni.iu.edu/about/people/person/franco-pestilli) (Associate Professor, University of Indiana), discusses "[brainlife.io](https://brainlife.io/) A free cloud platform for secure, reproducible neuroscience data management, analysis and visualization."
+Guest speaker Franco Pestilli (Associate Professor, University of Indiana), discusses "[brainlife.io](https://brainlife.io/) A free cloud platform for secure, reproducible neuroscience data management, analysis and visualization."
 
 [Video Presentation](https://www.youtube.com/watch?v=5wW5Q0adRzE&feature=youtu.be) is now available
 

--- a/content/resources/tutorials/pond-lake.md
+++ b/content/resources/tutorials/pond-lake.md
@@ -23,7 +23,7 @@ Here we will learn how to set up a **local** FAIR metadata store, which is known
 
 ## Before you start
 
-* Raw data files need to be organized as per the **BIDS format** (see [Converting DICOM to BIDS](http://resources/tutorials/dicom-to-bids/) tutorial)
+* Raw data files need to be organized as per the **BIDS format** (see [Converting DICOM to BIDS](/resources/tutorials/dicom-to-bids/) tutorial)
 * A **data dictionary** that can be used for both BIDS and NIDM compliant representations for ReproPonds and Lake is available (see [Implementing data management basics:  Creating a BIDS Data Dictionary and Adding Semantics for FAIR](/resources/tutorials/data-dictionary/)
   * The ReproPond is built from the **nidm.ttl** file containing semantically-enhanced subject-level data
 * The **Neurobagel tools** need to be installed.  To run the Neurobagel Docker, the Docker service needs to be installed on the host machine (refer [https://docs.docker.com/desktop/install/linux/](https://docs.docker.com/desktop/install/linux/)).  Also ensure that there is a docker group setup and the current user is a member of the docker and root groups (as per [https://docs.docker.com/engine/install/linux-postinstall/](https://docs.docker.com/engine/install/linux-postinstall/)):

--- a/content/resources/tutorials/repronim-containers.md
+++ b/content/resources/tutorials/repronim-containers.md
@@ -212,5 +212,5 @@ on if you need to extend or redo your analysis.
   and [ds000003-qc][https://github.com/ReproNim/ds000003-qc].
 
 [reproman]: http://reproman.repronim.org
-[datalad rerun]: http://docs.datalad.org/projects/container/en/latest/generated/man/datalad-rerun.html
-[datalad uninstall]: http://docs.datalad.org/projects/container/en/latest/generated/man/datalad-uninstall.html
+[datalad rerun]: http://docs.datalad.org/en/stable/generated/man/datalad-rerun.html
+[datalad uninstall]: http://docs.datalad.org/en/stable/generated/man/datalad-uninstall.html

--- a/data/fellowsresources.yaml
+++ b/data/fellowsresources.yaml
@@ -222,15 +222,6 @@ resources:
   - title: "Reproducible Data Management with DataLad"
     type: "Talk"
     audience: "Researchers, Infrastructure managers"
-    links:
-      - "https://onedrive.live.com/?authkey=%21AFsNiGzveqZ750s&id=86184EF59C004002%21416672&cid=86184EF59C004002&parId=root&parQt=sharedby&o=OneUp"
-    fellow: "Julian Kosciessa"
-
-  - title: "Reproducible Data Management with DataLad"
-    type: "Talk"
-    audience: "Researchers, Infrastructure managers"
-    links:
-      - "https://onedrive.live.com/?authkey=%21AANsp4ZosaSOK2o&id=86184EF59C004002%21416988&cid=86184EF59C004002&parId=root&parQt=sharedby&o=OneUp"
     fellow: "Julian Kosciessa"
 
   - title: "Reproducible Neuroimaging - open source guide"


### PR DESCRIPTION
Fixes https://github.com/ReproNim/repronim.org/issues/197

Most of the work here was configuring the link checker to skip sites that failed with the link checker, but that succeed in the browser. 

However, there were also some links that were just dead. For those, if I was able to quickly find a suitable replacement, I went ahead. Otherwise, I just removed.

@juliebates Could you please have a look any removed/replaced links? Especially for personal web pages of presenters, maybe they can be replaced with updated links?

I'll put this in as a draft for now, but I propose we merge as-is (or close to it) and file an issue for each specific link that needs adjustment/feedback so we dont hold up this work and we also dont lose track.