### PR TITLE
Add module-intro redirect and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,25 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build Commands
+- Local development: `hugo server`
+- Production build: `hugo --gc --minify`
+
+## Test Commands
+- Verify site builds: `hugo --gc --minify`
+- Check links: Run local server and validate with browser tools
+
+## Code Style Guidelines
+- Content: Write clear, concise Markdown with proper headings (h2, h3, etc.)
+- Frontmatter: Use YAML format with consistent property naming
+- Shortcodes: Prefer existing shortcodes (rn-button, people, fellows-resources)
+- HTML: Minimize direct HTML in content files unless necessary
+- Images: Store in /static/images/ with descriptive filenames
+- File organization: Follow existing content directory structure
+- Links: Use relative URLs for internal links
+- Code blocks: Use proper language identifiers (```bash, ```python, etc.)
+
+## Data Files
+- YAML files in /data/ follow snake_case naming
+- Structure new data files similar to existing ones

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,3 +5,9 @@ command = "hugo --gc --minify -b ${DEPLOY_PRIME_URL}"
 [build.environment]
 HUGO_VERSION = "0.132.2"
 DEPLOY_PRIME_URL = "https://dev.repronim.org"
+
+[[redirects]]
+  from = "/module-intro/*"
+  to = "https://www.repronim.org/module-intro/:splat"
+  status = 200
+  force = true


### PR DESCRIPTION
## Summary
- Add redirect in netlify.toml to proxy /module-intro/ to https://www.repronim.org/module-intro/
- Create CLAUDE.md with build instructions and style guidelines for agentic coding tools

## Test plan
- Verify the redirect works after deployment to Netlify

🤖 Generated with [Claude Code](https://claude.ai/code)