### PR TITLE
Do check links in main branch

### DIFF
--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -1,6 +1,9 @@
 name: Check Links
 on:
   pull_request: {}
+  push:
+    branches:
+      - main
   schedule:
     - cron: '0 14 * * 2'  # Tuesday at 9 AM Eastern (2 PM UTC)
 


### PR DESCRIPTION
Not testing main might result in odd/confusing state of CI showing the most recent run red whenever merging some PR in which check was red, although in reality situation might be different (green). And could also happen vice versa. So best would be to run it upon merges too

Currently I see only

<img width="3479" height="2159" alt="image" src="https://github.com/user-attachments/assets/ba1949a4-7f97-4f35-bde8-25ccf16ad367" />
