### PR TITLE
Remove commented _deprecated_module-workflows redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,13 +6,6 @@ command = "hugo --gc --minify -b ${DEPLOY_PRIME_URL}"
 HUGO_VERSION = "0.132.2"
 DEPLOY_PRIME_URL = "https://repronim.org"
 
-# GitHub Pages redirects for ReproNim repositories
-# TODO investigate
-# [[redirects]]
-#   from = "/_deprecated_module-workflows/*"
-#   to = "https://legacy.repronim.org/_deprecated_module-workflows/:splat"
-#   status = 301
-#   force = true
 
 [[redirects]]
   from = "/brainhack_ohbm18/*"


### PR DESCRIPTION
Removes the commented redirect section for `_deprecated_module-workflows/*` from netlify.toml as discussed in issue #336.

Closes #336

🤖 Generated with [Claude Code](https://claude.ai/code)