### PR TITLE
Update link for Seb Urchs

### DIFF
--- a/content/about/webinars.md
+++ b/content/about/webinars.md
@@ -196,7 +196,7 @@ Guest speaker and ReproNim Affiliate [Peer Herholz](https://peerherholz.github.i
 [Video Presentation](https://youtu.be/HwQzvQn2Who) is now available. Slides will be made available as soon as possible.
 
 ### Friday, February 4, 2022 at 2pm EST
-[Sebastian Urchs](https://www.surchs.com/) joins us from McGill to discuss linked data principles and how they can be used to integrate data via metadata, with an illuminating presentation on Annotation 101: Linked Data 101 and the Semantic Web.
+[Sebastian Urchs](https://github.com/surchs) joins us from McGill to discuss linked data principles and how they can be used to integrate data via metadata, with an illuminating presentation on Annotation 101: Linked Data 101 and the Semantic Web.
 
 [Video Presentation](https://youtu.be/vP_9Fo29o_E) and
 [Slides](https://docs.google.com/presentation/d/1AWNZsRTf9aZr3OBFY33Z38L8UIe1HzXWPTE8addXhUM/edit#slide=id.p) are now available.


### PR DESCRIPTION
in reference to his 2022 webinar presentation
His personal .com site no longer exists, replacing it here withi his current github page, because there is reference to the annotation work in 2022 there, which relates to his presentation topic.  https://github.com/surchs