### PR TITLE
fellows resources page should work in dark mode

### DIFF
--- a/static/css/fellows-resources.css
+++ b/static/css/fellows-resources.css
@@ -6,8 +6,7 @@
 }
 
 .fellows-resource-box {
-  background: #fff;
-  border: 1px solid #ccc; /* Thin border */
+  border: 1px solid rgba(128, 128, 128, 0.3);
   border-radius: 4px;
   width: calc(100% - 1rem);
   box-sizing: border-box;


### PR DESCRIPTION
https://github.com/ReproNim/repronim.org/issues/422
remove background color and use grey border for fellows resources shortcode

Let the background color inherit so this shortcode works with light and dark mode