### PR TITLE
Update Webinars Page for December webinar

### DIFF
--- a/content/about/webinars.md
+++ b/content/about/webinars.md
@@ -54,7 +54,9 @@ Webinar Topic: Details to be announced
 
 ### Friday, December 5, 2025 at 2pm ET
 
-[Catie Chang](https://engineering.vanderbilt.edu/bio/catie-chang/) (Vanderbilt University, Departments of Computer Science, Electrical & Computer Engineering, Biomedical Engineering, and PI, [neurdylab](https://www.cchanglab.net/research)), and [Roza Bayrak](https://rgbayrak.github.io/) (Vanderbilt University, Electrical & Computer Engineering) join us to discuss how time-varying states of alertness and autonomic activity manifest in fMRI signals, along with tools/methods for joint analysis of fMRI and peripheral physiological signals in their presentation: “Dynamic brain-body states: implications for reproducible and interpretable neuroimaging.”
+[Catie Chang](https://engineering.vanderbilt.edu/bio/catie-chang/) (Vanderbilt University, Departments of Computer Science, Electrical & Computer Engineering, Biomedical Engineering, and PI, [neurdylab](https://www.cchanglab.net/research)), and [Roza Bayrak](https://rgbayrak.github.io/) (Vanderbilt University, Electrical & Computer Engineering) join us to discuss how time-varying states of alertness and autonomic activity manifest in fMRI signals, along with tools/methods for joint analysis of fMRI and peripheral physiological signals.
+
+Presentation Title: “Dynamic brain-body states: implications for reproducible and interpretable neuroimaging.”
 
 [Video Presentation](https://youtu.be/jzPISfLsaPo) is now available.
 


### PR DESCRIPTION
Roll December 2025 entry down to 'Webinars to Date' as it is now completed.

Add link to video recording.