### PR TITLE
Update webinars page - April video link, move up May entry

### DIFF
--- a/content/about/webinars.md
+++ b/content/about/webinars.md
@@ -20,6 +20,7 @@ Webinar Topic: Details to be announced
 
 [Webinar Registration](https://umassmed.zoom.us/meeting/register/mhxcAm_7R_msH3__kO0Lgg) (Please note our new registration link)
 
+
 ### Friday, June 5, 2026 at 2pm ET
 
 Speaker: [Hugh Garavan](https://scholar.google.com/citations?user=EwNVxgEAAAAJ&hl=en) (University of Vermont) is our featured speaker this month.

--- a/content/about/webinars.md
+++ b/content/about/webinars.md
@@ -12,23 +12,13 @@ Browse our complete collections of ReproNim webinar [videos](https://www.youtube
 ## Upcoming webinars
 
 
-### Friday, April 3, 2026 at 2pm ET
-
-ReproNim faculty member [Satra Ghosh](https://mcgovern.mit.edu/profile/satrajit-ghosh/) (Massachusetts Institute of Technology, Senior Research Scientist, and Director of the [Open Data in Neuroscience Initiative](https://odin.mit.edu/index.html) at McGovern Institute for Brain Research at MIT) is our featured speaker this month. Satra brings a very broadly knowledgeable perspective to bear on all of his endeavors, and his work encompasses a wealth of expertise in computer science, computational neuroscience and neuroimaging.
-
-Presentation Title:“Undata - an AI-assisted unraveling of challenges around data models and schemas.” 
-
-[Webinar Registration](https://umassmed.zoom.us/meeting/register/mhxcAm_7R_msH3__kO0Lgg) (Please note our new registration link)
-
-Video Presentation and Slides will be made available as soon as possible following the webinar.
-
-
 ### Friday, May 1, 2026 at 2pm ET
 
 Speaker: ReproNim faculty member [Jeffrey Grethe](https://profiles.ucsd.edu/jeffrey.grethe) (UCSD) is our featured speaker this month.
 
 Webinar Topic: Details to be announced
 
+[Webinar Registration](https://umassmed.zoom.us/meeting/register/mhxcAm_7R_msH3__kO0Lgg) (Please note our new registration link)
 
 ### Friday, June 5, 2026 at 2pm ET
 
@@ -38,6 +28,15 @@ Webinar Topic: Details to be announced
 
 
 ## Webinar presentations to date
+
+### Friday, April 3, 2026 at 2pm ET
+
+ReproNim faculty member [Satra Ghosh](https://mcgovern.mit.edu/profile/satrajit-ghosh/) (Massachusetts Institute of Technology, Senior Research Scientist, and Director of the [Open Data in Neuroscience Initiative](https://odin.mit.edu/index.html) at McGovern Institute for Brain Research at MIT) is our featured speaker this month. Satra brings a very broadly knowledgeable perspective to bear on all of his endeavors, and his work encompasses a wealth of expertise in computer science, computational neuroscience and neuroimaging.
+
+Presentation Title:“Undata - an AI-assisted unraveling of challenges around data models and schemas.” 
+
+[Video Presentation](https://youtu.be/AgI32-hCNsM) is now available.
+
 
 ### Friday, March 6, 2026 at 2pm ET
 

--- a/content/about/webinars.md
+++ b/content/about/webinars.md
@@ -34,7 +34,7 @@ Webinar Topic: Details to be announced
 
 ReproNim faculty member [Satra Ghosh](https://mcgovern.mit.edu/profile/satrajit-ghosh/) (Massachusetts Institute of Technology, Senior Research Scientist, and Director of the [Open Data in Neuroscience Initiative](https://odin.mit.edu/index.html) at McGovern Institute for Brain Research at MIT) is our featured speaker this month. Satra brings a very broadly knowledgeable perspective to bear on all of his endeavors, and his work encompasses a wealth of expertise in computer science, computational neuroscience and neuroimaging.
 
-Presentation Title:“Undata - an AI-assisted unraveling of challenges around data models and schemas.” 
+Presentation Title: “Undata - an AI-assisted unraveling of challenges around data models and schemas.”
 
 [Video Presentation](https://youtu.be/AgI32-hCNsM) is now available.
 


### PR DESCRIPTION
Add video link for April 2026 webinar, move down to Past Presentations, roll up May in Upcoming presentations