### PR TITLE
Remove "new site launch" banner from homepage

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -5,34 +5,7 @@ toc: false
 
 <style>
     h2, p { text-align: center; }
-    .legacy-banner {
-        background-color: var(--color-info-bg, #e7f3ff);
-        border: 1px solid var(--color-info-border, #b3d9ff);
-        color: var(--color-info-text, #333);
-        border-radius: 4px;
-        padding: 12px;
-        margin-bottom: 20px;
-        text-align: center;
-    }
-    .legacy-banner a {
-        color: var(--color-info-link, #0066cc);
-        text-decoration: underline;
-    }
-    @media (prefers-color-scheme: dark) {
-        .legacy-banner {
-            background-color: #1a2332;
-            border-color: #2d3748;
-            color: #e2e8f0;
-        }
-        .legacy-banner a {
-            color: #63b3ed;
-        }
-    }
 </style>
-
-<div class="legacy-banner">
-    📢 <strong>New Site Launch:</strong> Welcome to our new ReproNim website! The previous version is still available at <a href="https://legacy.repronim.org">legacy.repronim.org</a>
-</div>
 
 A national biotechnology development center dedicated to developing tools and services to increase efficiency, rigor, reproducibility, transparency and FAIRness in neuroimaging.
 


### PR DESCRIPTION
The site is no longer new. Removes the announcement div and its now-unused `.legacy-banner` styles from `content/_index.md`. Builds clean on Hugo 0.161.1.

Closes #475

🤖 Generated with [Claude Code](https://claude.com/claude-code)