### PR TITLE
Add minimalistic introduction of STAMPED Principles alongside YODA references

### DIFF
--- a/content/about/principles/_index.md
+++ b/content/about/principles/_index.md
@@ -98,5 +98,5 @@ As indicated by the blue highlights in the figure below, four core actions are k
 
 ![A diagram showing how ReproNim's principles and core actions work together to reproducible neuroimaging.](/images/principles-of-neuroimaging.jpg)
 
-> **See also:** [STAMPED Principles](https://stamped-principles.org/) — a complimentary vocabulary (**S**elf-contained, **T**racked, **A**ctionable, **M**odular, **P**ortable, **E**phemeral, **D**istributable) that consolidates the ReproNim principles into an actionable checklist for individual research objects. STAMPED builds on the earlier [YODA Principles](https://github.com/myyoda) developed by ReproNim and the DataLad Collaborating Project.
+> **See also:** [STAMPED Principles](https://stamped-principles.org/) — a complementary vocabulary (**S**elf-contained, **T**racked, **A**ctionable, **M**odular, **P**ortable, **E**phemeral, **D**istributable) that consolidates the ReproNim principles into an actionable checklist for individual research objects. STAMPED builds on the earlier [YODA Principles](https://github.com/myyoda) developed by ReproNim and the DataLad Collaborating Project.
 

--- a/content/about/principles/_index.md
+++ b/content/about/principles/_index.md
@@ -97,3 +97,6 @@ As indicated by the blue highlights in the figure below, four core actions are k
    Containers provide a portable and self-contained environment for running software, ensuring that the analysis can be executed consistently across different computing environments (Principle 3). Containers encapsulate all of the software dependencies needed to run an analysis, making it easier to share software (Principle 4) and reproduce results.
 
 ![A diagram showing how ReproNim's principles and core actions work together to reproducible neuroimaging.](/images/principles-of-neuroimaging.jpg)
+
+> **See also:** [STAMPED Principles](https://stamped-principles.org/) — a complimentary vacabulary (**S**elf-contained, **T**racked, **A**ctionable, **M**odular, **P**ortable, **E**phemeral, **D**istributable) that consolidates the ReproNim principles into an actionable checklist for individual research objects. STAMPED builds on the earlier [YODA Principles](https://github.com/myyoda) developed by ReproNim and the DataLad Collaborating Project.
+

--- a/content/about/principles/_index.md
+++ b/content/about/principles/_index.md
@@ -98,5 +98,5 @@ As indicated by the blue highlights in the figure below, four core actions are k
 
 ![A diagram showing how ReproNim's principles and core actions work together to reproducible neuroimaging.](/images/principles-of-neuroimaging.jpg)
 
-> **See also:** [STAMPED Principles](https://stamped-principles.org/) — a complimentary vacabulary (**S**elf-contained, **T**racked, **A**ctionable, **M**odular, **P**ortable, **E**phemeral, **D**istributable) that consolidates the ReproNim principles into an actionable checklist for individual research objects. STAMPED builds on the earlier [YODA Principles](https://github.com/myyoda) developed by ReproNim and the DataLad Collaborating Project.
+> **See also:** [STAMPED Principles](https://stamped-principles.org/) — a complimentary vocabulary (**S**elf-contained, **T**racked, **A**ctionable, **M**odular, **P**ortable, **E**phemeral, **D**istributable) that consolidates the ReproNim principles into an actionable checklist for individual research objects. STAMPED builds on the earlier [YODA Principles](https://github.com/myyoda) developed by ReproNim and the DataLad Collaborating Project.
 

--- a/content/about/principles/data_management.md
+++ b/content/about/principles/data_management.md
@@ -39,7 +39,7 @@ We recommend using  [**DataLad**](/resources/tools/datalad/): for managing and s
 * ***Some things you can do***
   * ***Learn more:***
     * Tutorial:  [Version control systems](https://www.repronim.org/module-reproducible-basics/02-vcs/)
-    * [**Yoda Principles**](https://handbook.datalad.org/en/latest/basics/101-127-yoda.html):  Version everything and build everything off these versions. Three simple rules for making it easier to track versions across datasets and code through consistent directory names and structures.
+    * [**STAMPED Principles**](https://stamped-principles.org/): Seven properties (**S**elf-contained, **T**racked, **A**ctionable, **M**odular, **P**ortable, **E**phemeral, **D**istributable) of scientific research objects — a generalization of the earlier [**YODA Principles**](https://github.com/myyoda) covering directory layout, version control, container-based execution, and distributability. Companion resources: [examples](https://examples.stamped-principles.org/) and [compliance checklist](https://checklist.stamped-principles.org/).
 
 **2c. Annotate data using standard, reproducible procedures**
 

--- a/content/resources/tutorials/repronim-containers.md
+++ b/content/resources/tutorials/repronim-containers.md
@@ -15,7 +15,7 @@ weight: 5
 ## Challenge
 
 Using version control and automation to execute procedures can produce re-executable and provenance-rich results, but the task can appear daunting.
-Following best-practices for file layouts (DataLad + YODA Principles) provide clear connections (via subdatasets) between the source data and the derivative data that is produced.
+Following best-practices for file layouts ([STAMPED Principles](https://stamped-principles.org/), building on the earlier [YODA Principles](https://github.com/myyoda)) provide clear connections (via subdatasets) between the source data and the derivative data that is produced.
 Additionally, utilizing `datalad run` with `repronim-containers` preserves the provenance of exactly what software versions were used and how, leaving a detailed trail for future work.
 
 ## Exercise
@@ -50,6 +50,7 @@ your use case:
 - [Datalad](https://datalad.org)
 - [datalad-container extension](http://docs.datalad.org/projects/container/en/latest/index.html)
 - [YODA Organigram](https://github.com/myyoda/poster/blob/master/ohbm2018.pdf)
+- [STAMPED Principles](https://stamped-principles.org/) — see also the [examples collection](https://examples.stamped-principles.org/) and [compliance checklist](https://checklist.stamped-principles.org/)
 - [Singularity/Apptainer](https://apptainer.org/)
 
 ## Step by step guide
@@ -71,7 +72,7 @@ pip install datalad-container
 
 ### Step 2: Start a DataLad dataset
 
-Following YODA, our dataset for the results is **the** dataset that will contain everything needed to produce those results.
+Following YODA (now generalized as [STAMPED](https://stamped-principles.org/) — Self-contained + Tracked + Distributable), our dataset for the results is **the** dataset that will contain everything needed to produce those results.
 
 ```bash
 mkdir ~/my-experiments


### PR DESCRIPTION
STAMPED (Self-contained, Tracked, Actionable, Modular, Portable, Ephemeral, Distributable) generalizes YODA's dataset-layout guidance into a checklist-able framework covering ReproNim principles 2, 3, and 4. It is introduced as a "see also" on the principles landing page, replaces the standalone YODA bullet under principle 2b (with YODA retained as ancestor), and is cross-linked from the containers tutorial (Challenge, required reading, and Step 2 dataset framing).

Also corrects "Yoda" -> "YODA" casing.